### PR TITLE
自動生成ファイルの設定変更・仮トップページの作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def top
+  end
+end

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -1,0 +1,8 @@
+div.container.mx-auto.my-10
+  h1.text-3xl.font-bold.underline
+    | Hello world!
+
+  button class="bg-gray-900 hover:bg-gray-800 text-white rounded px-4 py-2"
+    | tailwind
+
+  button.btn.btn-primary daisyUI

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,13 @@ module Myapp
     config.load_defaults 7.1
 
     config.generators.template_engine = :slim # テンプレートエンジンをslimに設定
-    
+
+    config.generators do |g|
+      g.skip_routes true # ルーティングを追加しない
+      g.helper false # ヘルパーを追加しない
+      g.test_framework nil # テストスクリプトを生成しない
+    end
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
+  root "static_pages#top"
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end


### PR DESCRIPTION
次の2つのissue項目を完了しました

自動生成は次のようにしています
- ルーティングの自動生成なし
- ヘルパーの自動生成なし
- テストファイルの自動生成なし

トップページはstatic_pagesコントローラーを新たに作成し，top アクションとtop.html.slimで作成しています。
ルートに配置しました。

https://github.com/g-sawada/u-on-zu/issues/28

https://github.com/g-sawada/u-on-zu/issues/27


close #27 
close #28 