### PR TITLE
pryを使用するために,bin/devを手動で実行するように変更

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server -b 0.0.0.0 -p 3000
 js: yarn build --watch
 css: yarn build:css --watch

--- a/compose.yml
+++ b/compose.yml
@@ -21,7 +21,7 @@ services:
       dockerfile: Dockerfile.dev # 開発用
 
     ## ./bin/devの実行内容はProcfile.devにまとめて記載し，foremanで起動する。rails sやyarn buildなどを記載
-    command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
+    command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && bin/rails server -b 0.0.0.0 -p 3000"
 
     tty: true
     stdin_open: true


### PR DESCRIPTION
compose.ymlのcommandで，bin/devではなくrails sのみ起動し，Procfile.devからrails sを削除して，js・cssのビルドウォッチャーは手動で別ターミナルから起動するように変更しました。