### PR TITLE
ユーザー登録機能の追加（Google認証はまだ）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+
+  add_flash_types :success, :info, :warning
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,22 @@ class UsersController < ApplicationController
 
   # 新規登録処理
   def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to root_path, success: 'ユーザー登録が完了しました'
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   # ユーザー削除処理
   def destroy
   end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:username, :email, :password, :password_confirmation, :occupation)
+  end
+
 end

--- a/app/javascript/react/entrypoints/test_entry.jsx
+++ b/app/javascript/react/entrypoints/test_entry.jsx
@@ -90,7 +90,7 @@ function TestGraph() {
     </ResponsiveContainer>
   );
 }
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbo:load', () => {
   const container = document.getElementById('test_graph');
   if (container) {
   createRoot(container).render(<TestGraph />);

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,9 @@ class User < ApplicationRecord
   validates :occupation,            presence: true
 
   enum occupation: {
-    student_elementary: 0, student_junior: 1, student_high: 2, student_college: 3, teacher_high_geography: 4,
-    teacher_high_social: 5, teacher_high_others: 6, teacher_junior_social: 7, teacher_junior_others: 8,
-    teacher_elementary: 9, researcher_geography: 10, researcher_others: 11, teacher_others: 12,
+    student_elementary: 0, student_junior: 1, student_high: 2, student_college: 3, teacher_elementary: 4,
+    teacher_junior_social: 5, teacher_junior_others: 6, teacher_high_geography: 7, teacher_high_social: 8,
+    teacher_high_others: 9, researcher_geography: 10, researcher_others: 11, teacher_others: 12,
     company_education: 13, company_others: 14, others: 15
   }
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,6 +4,7 @@ html
     title
       | Myapp
     meta[name="viewport" content="width=device-width,initial-scale=1"]
+    / meta[name="turbo-visit-control" content="reload"] //これをするとページ全体を再読み込みすることになる
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag "application", "data-turbo-track": "reload"

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -1,4 +1,8 @@
 div.container.mx-auto.my-10
+  - flash.each do |message_type, message|
+    div class="alert alert-#{message_type}"
+      = message
+
   h1.text-3xl.font-bold.underline
     | Hello world!
 

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -31,6 +31,10 @@
             = f.label :password_confirmation, class: 'text-xl fond-bold'
             = f.password_field :password_confirmation, class: 'w-full input input-borderd input-primary'
 
+          .my-5.space-y-3
+            = f.label :occupation, class: 'text-xl fond-bold'
+            = f.select :occupation, User.occupations.keys.map { |k| [t("enum.user.occupation.#{k}"), k] }, { prompt: "選択して下さい" }, class: 'w-full select select-bordered select-primary'
+
           .my-10.flex.justify-center
             = f.submit '新規登録', class: 'btn btn-primary'
 

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -6,10 +6,7 @@
       .my-10
         = form_with model: @user, local: true do |f|
           - if @user.errors.any?
-            div#error_explanation
-              h2
-                = pluralize(@user.errors.count, "error")
-                | prohibited this user from being saved:
+            div.alert.alert-error#error_explanation
               ul
                 - @user.errors.full_messages.each do |message|
                   li

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -9,3 +9,22 @@ ja:
         password: パスワード
         password_confirmation: パスワード(確認)
         occupation: 職業
+  enum:
+    user:
+      occupation:
+        student_elementary: 小学生
+        student_junior: 中学生
+        student_high: 高校生
+        student_college: 大学生
+        teacher_elementary: 小学校教員
+        teacher_junior_social: 中学校教員（社会）
+        teacher_junior_others: 中学校教員（その他）
+        teacher_high_geography: 高校教員（地理）
+        teacher_high_social: 高校教員（歴史・公民）
+        teacher_high_others: 高校教員（その他）
+        researcher_geography: 大学教員・研究者（地理分野）
+        researcher_others: 大学教員・研究者（その他）
+        teacher_others: 学校以外の教員・講師
+        company_education: 一般企業社員（教育関連）
+        company_others: 一般企業社員（その他）
+        others: その他


### PR DESCRIPTION
次のissueの項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/34

- Google認証は後日にする
- Google認証後，職業を設定するページは別途設けることにして，こちらの通常登録は全ての項目を必須にする
- flashメッセージにsuccessを追加するため，親コントローラに追加処理を記述（ついでにinfoも）
- トップページに遷移するとReactの描画がされなくなっていたので，turbo: loadをイベントリスナーに追加

close #34 