### PR TITLE
仮のログイン前・ログイン後ヘッダーの作成

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,4 +10,7 @@ html
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", type: "module"
   body
+    header.mb-6 
+      = render partial: "shared/before_login_header"
+      
     = yield

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -1,0 +1,7 @@
+.navbar.flex.space-x-1.bg-base-300.justify-end
+  .btn.btn-ghost.text-xl
+    = link_to "Top", root_path
+  .btn.btn-ghost.text-xl
+    = link_to "新規登録", new_user_path
+  .btn.btn-ghost.text-xl
+    = link_to "ログイン", "#"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,0 +1,7 @@
+.navbar.flex.space-x-1.bg-base-300.justify-end
+  .btn.btn-ghost.text-xl
+    = link_to "Top", root_path
+  .btn.btn-ghost.text-xl
+    = link_to "マイページ", "#"
+  .btn.btn-ghost.text-xl
+    = link_to "ログアウト", "#"


### PR DESCRIPTION
次のissue項目に従って，仮のヘッダーを作成しました。
https://github.com/g-sawada/u-on-zu/issues/89

- レイアウトファイルでは，ひとまずログイン前ヘッダーのみ表示しています
- リンクは，各ページを作成次第，随時実装することとします


close #89 