### PR TITLE
メイン画面canvasの作成。ドロワーを使ったレイアウトの導入

### DIFF
--- a/app/controllers/canvas_controller.rb
+++ b/app/controllers/canvas_controller.rb
@@ -1,0 +1,4 @@
+class CanvasController < ApplicationController
+  def index
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./react/entrypoints/test_entry"
+import "./react/entrypoints/canvas_entry"

--- a/app/javascript/react/canvas/components/bottom_drawer.jsx
+++ b/app/javascript/react/canvas/components/bottom_drawer.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
+import Button from '@mui/material/Button';
+import List from '@mui/material/List';
+import Divider from '@mui/material/Divider';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+// import InboxIcon from '@mui/icons-material/MoveToInbox';
+// import MailIcon from '@mui/icons-material/Mail';
+
+
+export default function BottomDrawer() {
+  const [state, setState] = useState(false);
+
+  const toggleDrawer = (open) => (event) => {
+    if (event && event.type === 'keydown' && (event.key === 'Tab' || event.key === 'Shift')) { 
+      return; 
+    }
+    setState(open);
+  };
+
+  const list = () => (
+    <>
+      <Box
+        sx={{ width: 'auto' }}
+        role="presentation"
+        onClick={toggleDrawer(false)}
+        onKeyDown={toggleDrawer(false)}
+      >
+        <List>
+          {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
+            <ListItem key={text} disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  {/* {index % 2 === 0 ? <InboxIcon /> : <MailIcon />} */}
+                </ListItemIcon>
+                <ListItemText primary={text} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+        <Divider />
+        <List>
+          {['All mail', 'Trash', 'Spam'].map((text, index) => (
+            <ListItem key={text} disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  {/* {index % 2 === 0 ? <InboxIcon /> : <MailIcon />} */}
+                </ListItemIcon>
+                <ListItemText primary={text} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Box>
+    </>
+  );
+
+  return (
+    <React.Fragment>
+      <div className='my-5'>
+        <button 
+          className='btn btn-primary btn-sm' 
+          onClick={toggleDrawer(true)}
+        >
+          Drawer
+        </button>
+      </div>
+      <Button className='btn btn-primary btn-sm ' onClick={toggleDrawer(true)}>bottom</Button>
+      <SwipeableDrawer
+        anchor='bottom'
+        open={state}
+        onClose={toggleDrawer(false)}
+        onOpen={toggleDrawer(true)}
+      >
+        {list()}
+      </SwipeableDrawer>
+    </React.Fragment>
+  );
+}

--- a/app/javascript/react/canvas/components/bottom_drawer.jsx
+++ b/app/javascript/react/canvas/components/bottom_drawer.jsx
@@ -1,16 +1,6 @@
 import React, { useState } from 'react';
 import Box from '@mui/material/Box';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
-import Button from '@mui/material/Button';
-import List from '@mui/material/List';
-import Divider from '@mui/material/Divider';
-import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-// import InboxIcon from '@mui/icons-material/MoveToInbox';
-// import MailIcon from '@mui/icons-material/Mail';
-
 
 export default function BottomDrawer() {
   const [state, setState] = useState(false);
@@ -25,36 +15,10 @@ export default function BottomDrawer() {
   const list = () => (
     <>
       <Box
-        sx={{ width: 'auto' }}
+        sx={{ width: '100%' }}
         role="presentation"
-        onClick={toggleDrawer(false)}
-        onKeyDown={toggleDrawer(false)}
       >
-        <List>
-          {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
-            <ListItem key={text} disablePadding>
-              <ListItemButton>
-                <ListItemIcon>
-                  {/* {index % 2 === 0 ? <InboxIcon /> : <MailIcon />} */}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
-        <Divider />
-        <List>
-          {['All mail', 'Trash', 'Spam'].map((text, index) => (
-            <ListItem key={text} disablePadding>
-              <ListItemButton>
-                <ListItemIcon>
-                  {/* {index % 2 === 0 ? <InboxIcon /> : <MailIcon />} */}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
+        <textarea className='textarea textarea-bordered textarea-lg w-full h-80'></textarea>
       </Box>
     </>
   );
@@ -66,10 +30,9 @@ export default function BottomDrawer() {
           className='btn btn-primary btn-sm' 
           onClick={toggleDrawer(true)}
         >
-          Drawer
+          Bottom
         </button>
       </div>
-      <Button className='btn btn-primary btn-sm ' onClick={toggleDrawer(true)}>bottom</Button>
       <SwipeableDrawer
         anchor='bottom'
         open={state}

--- a/app/javascript/react/canvas/components/graph.jsx
+++ b/app/javascript/react/canvas/components/graph.jsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import {
+  ComposedChart,
+  Line,
+  Area,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  Scatter,
+  ResponsiveContainer,
+  Label,
+} from 'recharts';
+import { data_tokyo } from './tokyo';
+// import { convertImage } from './convertImage';
+
+export default function Graph() {
+  const annualRain = data_tokyo.reduce((total, item) => total + item.rain, 0);
+  const annualAveTemp = (data_tokyo.reduce((total, item) => total + item.temp_ave, 0) / 12);
+
+  const [lineDotSize, setLineDotSize] = useState(4);
+  const [barStrokeWidth, setBarStrokeWidth] = useState(1);
+  const [tempDomainMax, setTempDomainMax] = useState(40);
+
+  const handleChangeNumber = (setter) => (e) => {
+    if (e.target.value !== '') {
+      setter(Number(e.target.value));
+    }
+    console.log(e.target.value);
+  }
+
+  const style = {fontFamily: "sans-serif, serif"}; //sans-serif→ゴシック，serif→明朝
+  return (
+    <div style={style}>
+      <ResponsiveContainer id="my-recharts-container" height={500} width={500}>
+        <ComposedChart
+          data={data_tokyo}
+          margin={{
+            top: 50,
+            right: 20,
+            bottom: 60,
+            left: 20,
+          }}
+          barGap={0}
+          id="my-recharts"
+        >
+          <rect width="100%" height="100%" fill="white" />
+          <text x={500 / 2} y={20} fill="black" textAnchor="middle" dominantBaseline="central">
+            <tspan fontSize="24">東京</tspan>
+          </text>
+          <CartesianGrid 
+            strokeDasharray=""
+            vertical={false}
+            stroke="gray"
+            strokeOpacity={0.5}
+            fill="white"
+            fillOpacity={0.2}
+            />
+          <XAxis 
+            dataKey="month"
+            scale="auto"
+            stroke="black"
+            />
+          <YAxis
+            yAxisId={1}
+            domain={[-30, tempDomainMax]}
+            tickCount={8}
+            stroke="black">
+            <Label value="気　温" dx={-25} writingMode="tb" fontSize={20} fill="black"/>
+            <Label value="(°Ｃ)" fontSize={12} fill="black" position="insideTopLeft" dx={20} dy={-30}/>
+          </YAxis>
+          <YAxis 
+            yAxisId={2}
+            orientation="right"
+            domain={[0, 700]}
+            tickCount={8}
+            stroke="black"
+            >
+            <Label value="降水量" dx={25} writingMode="tb" fontSize={20} fill="black"/>
+            <Label value="(mm)" fontSize={12} fill="black" position="insideTopLeft" dx={7} dy={-30}/>
+          </YAxis>
+          <Line 
+            yAxisId={1}
+            isAnimationActive={false}
+            type="linear"
+            dataKey="temp_ave"
+            dot={{ r: lineDotSize }}
+            stroke="red"
+            strokeWidth={1.5}/>
+          <Bar 
+            yAxisId={2}
+            dataKey="rain"
+            barSize={50}
+            fill="cyan"
+            stroke="black"
+            strokeWidth={barStrokeWidth}
+            />
+          <Tooltip />
+          <text x={500 / 2} y={460} fill="black" textAnchor="middle" dominantBaseline="central">
+              <tspan fontSize="16">年平均気温: {annualAveTemp.toFixed(1)}°C，年間降水量: {annualRain.toFixed(1)}mm </tspan>
+          </text>
+        </ComposedChart>
+      </ResponsiveContainer>
+
+      <div id="input">
+        <div>DotSize</div>
+        <input type='number' step={0.5} value={lineDotSize} onChange={handleChangeNumber(setLineDotSize)}/>
+        <p>DotSize: {lineDotSize} </p>
+      </div>
+      <div id="input2">
+        <div>BarStrokeWidth</div>
+        <input type='number' step={0.5} value={barStrokeWidth} onChange={handleChangeNumber(setBarStrokeWidth)}/>
+        <p>BarStrokeWidth: {barStrokeWidth} </p>
+      </div>
+      <div id="input3">
+        <div>TempMax</div>
+          <input type='number' step={5} value={tempDomainMax} onChange={handleChangeNumber(setTempDomainMax)}/>
+          <p>TempMax: {tempDomainMax} </p>
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/react/canvas/components/right_drawer.jsx
+++ b/app/javascript/react/canvas/components/right_drawer.jsx
@@ -67,7 +67,7 @@ export default function PersistentDrawerRight() {
   return (
     <Box sx={{ display: 'flex' }} className='bg-red-200'>
       <Main open={open}>
-        <button onClick={handleDrawerOpen} className='btn btn-info'>Open</button>
+        <button onClick={handleDrawerOpen} className='btn btn-info'>Right</button>
         <Typography paragraph>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Rhoncus dolor purus non
@@ -117,7 +117,7 @@ export default function PersistentDrawerRight() {
           open={open}
         > {/* ここからDrawerの中身 */}
           <div width='100%' height='100%' className='bg-red'>
-            <div onClick={handleDrawerClose} className='btn btn-primary'>Icon</div>
+            <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
             <div className='font-bold'>これはドロワーの中身です</div>
           </div>
         </Drawer>

--- a/app/javascript/react/canvas/components/right_drawer.jsx
+++ b/app/javascript/react/canvas/components/right_drawer.jsx
@@ -1,23 +1,10 @@
-import * as React from 'react';
-import { styled, useTheme } from '@mui/material/styles';
+import React, { useState } from 'react';
+import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
-import MuiAppBar from '@mui/material/AppBar';
-import Toolbar from '@mui/material/Toolbar';
-import CssBaseline from '@mui/material/CssBaseline';
-import List from '@mui/material/List';
 import Typography from '@mui/material/Typography';
-// import Divider from '@mui/material/Divider';
-import IconButton from '@mui/material/IconButton';
-// import MenuIcon from '@mui/icons-material/Menu';
-// import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-// import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-// import ListItem from '@mui/material/ListItem';
-// import ListItemButton from '@mui/material/ListItemButton';
-// import ListItemIcon from '@mui/material/ListItemIcon';
-// import ListItemText from '@mui/material/ListItemText';
-// import InboxIcon from '@mui/icons-material/MoveToInbox';
-// import MailIcon from '@mui/icons-material/Mail';
+import { makeStyles } from "@material-ui/core/styles";
+
 
 const drawerWidth = 240;
 
@@ -47,35 +34,8 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
   }),
 );
 
-const AppBar = styled(MuiAppBar, {
-  shouldForwardProp: (prop) => prop !== 'open',
-})(({ theme, open }) => ({
-  transition: theme.transitions.create(['margin', 'width'], {
-    easing: theme.transitions.easing.sharp,
-    duration: theme.transitions.duration.leavingScreen,
-  }),
-  ...(open && {
-    width: `calc(100% - ${drawerWidth}px)`,
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    marginRight: drawerWidth,
-  }),
-}));
-
-const DrawerHeader = styled('div')(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  padding: theme.spacing(0, 1),
-  // necessary for content to be below app bar
-  ...theme.mixins.toolbar,
-  justifyContent: 'flex-start',
-}));
-
 export default function PersistentDrawerRight() {
-  const theme = useTheme();
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   const handleDrawerOpen = () => {
     setOpen(true);
@@ -85,28 +45,29 @@ export default function PersistentDrawerRight() {
     setOpen(false);
   };
 
+  const useStyles = makeStyles({
+    drawer: {
+      position: 'relative',
+      marginLeft: "auto",
+      width: drawerWidth,
+      "& .MuiBackdrop-root": {
+        display: "none"
+      },
+      "& .MuiDrawer-paper": {
+        width: drawerWidth,
+        height: "100%",
+        position: "absolute",
+        backgroundColor: "green",
+      }
+    }
+  });
+  const classes = useStyles();
+
+
   return (
-    <Box sx={{ display: 'flex' }}>
-      <CssBaseline />
-      <AppBar position="fixed" open={open}>
-        <Toolbar>
-          <Typography variant="h6" noWrap sx={{ flexGrow: 1 }} component="div">
-            Persistent drawer
-          </Typography>
-          <IconButton
-            color="inherit"
-            aria-label="open drawer"
-            edge="end"
-            onClick={handleDrawerOpen}
-            sx={{ ...(open && { display: 'none' }) }}
-          >
-            MenuIcon
-            {/* <MenuIcon /> */}
-          </IconButton>
-        </Toolbar>
-      </AppBar>
+    <Box sx={{ display: 'flex' }} className='bg-red-200'>
       <Main open={open}>
-        <DrawerHeader />
+        <button onClick={handleDrawerOpen} className='btn btn-info'>Open</button>
         <Typography paragraph>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Rhoncus dolor purus non
@@ -135,51 +96,31 @@ export default function PersistentDrawerRight() {
           posuere sollicitudin aliquam ultrices sagittis orci a.
         </Typography>
       </Main>
-      <Drawer
-        sx={{
-          width: drawerWidth,
-          flexShrink: 0,
-          '& .MuiDrawer-paper': {
+        <Drawer
+          sx={{
+            position: 'relative',
+            marginLeft: "auto",
             width: drawerWidth,
-          },
-        }}
-        variant="persistent"
-        anchor="right"
-        open={open}
-      >
-        <DrawerHeader>
-          <IconButton onClick={handleDrawerClose}>
-            {/* {theme.direction === 'rtl' ? <ChevronLeftIcon /> : <ChevronRightIcon />} */}
-            Icon
-          </IconButton>
-        </DrawerHeader>
-        {/* <Divider /> */}
-        {/* <List>
-          {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
-            <ListItem key={text} disablePadding>
-              <ListItemButton>
-                <ListItemIcon>
-                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
-        <Divider />
-        <List>
-          {['All mail', 'Trash', 'Spam'].map((text, index) => (
-            <ListItem key={text} disablePadding>
-              <ListItemButton>
-                <ListItemIcon>
-                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List> */}
-      </Drawer>
+            "& .MuiBackdrop-root": {
+              display: "none"
+            },
+            "& .MuiDrawer-paper": {
+              width: drawerWidth,
+              height: "100%",
+              position: "absolute",
+              backgroundColor: "limegreen",
+            }
+          }}
+          // className={[classes.drawer, 'text-3xl']}
+          variant="persistent"
+          anchor="right"
+          open={open}
+        > {/* ここからDrawerの中身 */}
+          <div width='100%' height='100%' className='bg-red'>
+            <div onClick={handleDrawerClose} className='btn btn-primary'>Icon</div>
+            <div className='font-bold'>これはドロワーの中身です</div>
+          </div>
+        </Drawer>
     </Box>
   );
 }

--- a/app/javascript/react/canvas/components/right_drawer.jsx
+++ b/app/javascript/react/canvas/components/right_drawer.jsx
@@ -1,0 +1,185 @@
+import * as React from 'react';
+import { styled, useTheme } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import MuiAppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import CssBaseline from '@mui/material/CssBaseline';
+import List from '@mui/material/List';
+import Typography from '@mui/material/Typography';
+// import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+// import MenuIcon from '@mui/icons-material/Menu';
+// import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+// import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+// import ListItem from '@mui/material/ListItem';
+// import ListItemButton from '@mui/material/ListItemButton';
+// import ListItemIcon from '@mui/material/ListItemIcon';
+// import ListItemText from '@mui/material/ListItemText';
+// import InboxIcon from '@mui/icons-material/MoveToInbox';
+// import MailIcon from '@mui/icons-material/Mail';
+
+const drawerWidth = 240;
+
+const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
+  ({ theme, open }) => ({
+    flexGrow: 1,
+    padding: theme.spacing(3),
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    marginRight: -drawerWidth,
+    ...(open && {
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+      marginRight: 0,
+    }),
+    /**
+     * This is necessary to enable the selection of content. In the DOM, the stacking order is determined
+     * by the order of appearance. Following this rule, elements appearing later in the markup will overlay
+     * those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures
+     * proper interaction with the underlying content.
+     */
+    position: 'relative',
+  }),
+);
+
+const AppBar = styled(MuiAppBar, {
+  shouldForwardProp: (prop) => prop !== 'open',
+})(({ theme, open }) => ({
+  transition: theme.transitions.create(['margin', 'width'], {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+  ...(open && {
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(['margin', 'width'], {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+    marginRight: drawerWidth,
+  }),
+}));
+
+const DrawerHeader = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  padding: theme.spacing(0, 1),
+  // necessary for content to be below app bar
+  ...theme.mixins.toolbar,
+  justifyContent: 'flex-start',
+}));
+
+export default function PersistentDrawerRight() {
+  const theme = useTheme();
+  const [open, setOpen] = React.useState(false);
+
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
+      <AppBar position="fixed" open={open}>
+        <Toolbar>
+          <Typography variant="h6" noWrap sx={{ flexGrow: 1 }} component="div">
+            Persistent drawer
+          </Typography>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="end"
+            onClick={handleDrawerOpen}
+            sx={{ ...(open && { display: 'none' }) }}
+          >
+            MenuIcon
+            {/* <MenuIcon /> */}
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Main open={open}>
+        <DrawerHeader />
+        <Typography paragraph>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Rhoncus dolor purus non
+          enim praesent elementum facilisis leo vel. Risus at ultrices mi tempus
+          imperdiet. Semper risus in hendrerit gravida rutrum quisque non tellus.
+          Convallis convallis tellus id interdum velit laoreet id donec ultrices.
+          Odio morbi quis commodo odio aenean sed adipiscing. Amet nisl suscipit
+          adipiscing bibendum est ultricies integer quis. Cursus euismod quis viverra
+          nibh cras. Metus vulputate eu scelerisque felis imperdiet proin fermentum
+          leo. Mauris commodo quis imperdiet massa tincidunt. Cras tincidunt lobortis
+          feugiat vivamus at augue. At augue eget arcu dictum varius duis at
+          consectetur lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa
+          sapien faucibus et molestie ac.
+        </Typography>
+        <Typography paragraph>
+          Consequat mauris nunc congue nisi vitae suscipit. Fringilla est ullamcorper
+          eget nulla facilisi etiam dignissim diam. Pulvinar elementum integer enim
+          neque volutpat ac tincidunt. Ornare suspendisse sed nisi lacus sed viverra
+          tellus. Purus sit amet volutpat consequat mauris. Elementum eu facilisis
+          sed odio morbi. Euismod lacinia at quis risus sed vulputate odio. Morbi
+          tincidunt ornare massa eget egestas purus viverra accumsan in. In hendrerit
+          gravida rutrum quisque non tellus orci ac. Pellentesque nec nam aliquam sem
+          et tortor. Habitant morbi tristique senectus et. Adipiscing elit duis
+          tristique sollicitudin nibh sit. Ornare aenean euismod elementum nisi quis
+          eleifend. Commodo viverra maecenas accumsan lacus vel facilisis. Nulla
+          posuere sollicitudin aliquam ultrices sagittis orci a.
+        </Typography>
+      </Main>
+      <Drawer
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+          },
+        }}
+        variant="persistent"
+        anchor="right"
+        open={open}
+      >
+        <DrawerHeader>
+          <IconButton onClick={handleDrawerClose}>
+            {/* {theme.direction === 'rtl' ? <ChevronLeftIcon /> : <ChevronRightIcon />} */}
+            Icon
+          </IconButton>
+        </DrawerHeader>
+        {/* <Divider /> */}
+        {/* <List>
+          {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
+            <ListItem key={text} disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                </ListItemIcon>
+                <ListItemText primary={text} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+        <Divider />
+        <List>
+          {['All mail', 'Trash', 'Spam'].map((text, index) => (
+            <ListItem key={text} disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                </ListItemIcon>
+                <ListItemText primary={text} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List> */}
+      </Drawer>
+    </Box>
+  );
+}

--- a/app/javascript/react/canvas/components/tokyo.js
+++ b/app/javascript/react/canvas/components/tokyo.js
@@ -1,0 +1,62 @@
+export const data_tokyo = [
+  {
+    month: 1,
+    temp_ave: 5.4,
+    rain: 59.7,
+  },
+  {
+    month: 2,
+    temp_ave: 6.1,
+    rain: 56.5,
+  },
+  {
+    month: 3,
+    temp_ave: 9.4,
+    rain: 116.0,
+  },
+  {
+    month: 4,
+    temp_ave: 14.3,
+    rain: 133.7,
+  },
+  {
+    month: 5,
+    temp_ave: 18.8,
+    rain: 139.7,
+  },
+  {
+    month: 6,
+    temp_ave: 21.9,
+    rain: 167.8,
+  },
+  {
+    month: 7,
+    temp_ave: 25.7,
+    rain: 156.2,
+  },
+  {
+    month: 8,
+    temp_ave: 26.9,
+    rain: 154.7,
+  },
+  {
+    month: 9,
+    temp_ave: 23.3,
+    rain: 224.9,
+  },
+  {
+    month: 10,
+    temp_ave: 18.0,
+    rain: 234.8,
+  },
+  {
+    month: 11,
+    temp_ave: 12.5,
+    rain: 96.3,
+  },
+  {
+    month: 12,
+    temp_ave: 7.7,
+    rain: 57.9,
+  },
+];

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Graph from './components/graph';
 import PersistentDrawerRight from './components/right_drawer';
-import BottomDrawer from './bottom_drawer';
+import BottomDrawer from './components/bottom_drawer';
 
 export default function CanvasApp() {
   return (
-    <div className='flex'>
+    <div className=''>
       {/* <div className='flex flex-1 justify-center items-center bg-blue-200'>
         <div className='mt-10'>
           <Graph />
@@ -15,7 +15,7 @@ export default function CanvasApp() {
         テスト
       </div> */}
       <PersistentDrawerRight />
-      {/* <BottomDrawer /> */}
+      <BottomDrawer />
     </div>
   )
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import Graph from './components/graph';
 
 export default function CanvasApp() {
   return (
-    <div className="text-2xl m-10">
-      <h1>My Canvas App</h1>
-      <p>It works!</p>
+    <div className='flex'>
+      <div className='flex flex-1 justify-center items-center bg-blue-200'>
+        <div className='mt-10'>
+          <Graph />
+        </div>
+      </div>
+      <div className='w-full flex-shrink-0 max-w-xs bg-green-200 '>
+        テスト
+      </div>
     </div>
   )
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function CanvasApp() {
+  return (
+    <div className="text-2xl m-10">
+      <h1>My Canvas App</h1>
+      <p>It works!</p>
+    </div>
+  )
+}

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Graph from './components/graph';
 import PersistentDrawerRight from './components/right_drawer';
+import BottomDrawer from './bottom_drawer';
 
 export default function CanvasApp() {
   return (
@@ -14,6 +15,7 @@ export default function CanvasApp() {
         テスト
       </div> */}
       <PersistentDrawerRight />
+      {/* <BottomDrawer /> */}
     </div>
   )
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import Graph from './components/graph';
+import PersistentDrawerRight from './components/right_drawer';
 
 export default function CanvasApp() {
   return (
     <div className='flex'>
-      <div className='flex flex-1 justify-center items-center bg-blue-200'>
+      {/* <div className='flex flex-1 justify-center items-center bg-blue-200'>
         <div className='mt-10'>
           <Graph />
         </div>
       </div>
       <div className='w-full flex-shrink-0 max-w-xs bg-green-200 '>
         テスト
-      </div>
+      </div> */}
+      <PersistentDrawerRight />
     </div>
   )
 }

--- a/app/javascript/react/entrypoints/canvas_entry.jsx
+++ b/app/javascript/react/entrypoints/canvas_entry.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+document.addEventListener('turbo:load', () => {
+  const container = document.getElementById('create-graph-app');
+  if (container) {
+  createRoot(container).render(<Test />);
+  } else {
+  console.log('test_app not found');
+  }
+})

--- a/app/javascript/react/entrypoints/canvas_entry.jsx
+++ b/app/javascript/react/entrypoints/canvas_entry.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import CanvasApp from '../canvas';
 
 document.addEventListener('turbo:load', () => {
-  const container = document.getElementById('create-graph-app');
+  const container = document.getElementById('canvas-app');
   if (container) {
-  createRoot(container).render(<Test />);
+  createRoot(container).render(<CanvasApp />);
   } else {
-  console.log('test_app not found');
+  console.log('canvas-app not found');
   }
 })

--- a/app/views/canvas/index.html.slim
+++ b/app/views/canvas/index.html.slim
@@ -1,2 +1,2 @@
-h1 Canvas#index
-p Find me in app/views/canvas/index.html.slim
+.mx-auto.w-full.my-10
+  #canvas-app

--- a/app/views/canvas/index.html.slim
+++ b/app/views/canvas/index.html.slim
@@ -1,2 +1,6 @@
-.mx-auto.w-full.my-10
-  #canvas-app
+.w-full.my-5#canvas-app
+
+.w-full
+  .mx-auto
+    .flex.justify-center
+      | test

--- a/app/views/canvas/index.html.slim
+++ b/app/views/canvas/index.html.slim
@@ -1,0 +1,2 @@
+h1 Canvas#index
+p Find me in app/views/canvas/index.html.slim

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,3 +14,6 @@ html
       = render partial: logged_in? ? "shared/header" : "shared/before_login_header"
     = render partial: "shared/flash_message"
     = yield
+  
+  .invisible.alert.alert-info.alert-success.alert-warning.alert-error
+

--- a/app/views/shared/_flash_message.html.slim
+++ b/app/views/shared/_flash_message.html.slim
@@ -1,4 +1,3 @@
-div
-  - flash.each do |message_type, message|
-    div class="alert alert-#{message_type} mb-10 rounded-none font-bold"
-      = message
+- flash.each do |message_type, message|
+  div class="alert alert-#{message_type} mb-10 rounded-none font-bold"
+    = message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "mypage", to: "profiles#show"
   get "mypage/edit", to: "profiles#edit"
   patch "mypage", to: "profiles#update"
+  get "canvas", to: "canvas#index"
   
   resources :users, only: %i[new create destroy]
   

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,7 @@ module.exports = {
           'success' : '#009485',
           'warning' : '#ff9900',
           'error' : '#ff5724',
+          // 'error' : '#e65023',
 
           '--rounded-box': '.5rem',          
           '--rounded-btn': '.5rem',        


### PR DESCRIPTION
次のissue項目を完了しました
ただし，グラフコンポーネントの描画は，コードとディレクトリの整理を先に行ってから実装することとし，別issueに切り出します。
https://github.com/g-sawada/u-on-zu/issues/43


https://github.com/g-sawada/u-on-zu/assets/118000212/782542fa-d838-49e4-87ae-a12b57a6a844


close #43


