### PR TITLE
グラフ設定値入力サイドバーのレイアウト作成

### DIFF
--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -9,9 +9,11 @@ import WrappedAccordion from "./wrapped_accordion";
 
 export default function GraphSettings({ lineDotSize, handleValueChange }) {
   const [expanded, setExpanded] = useState(false);
-  const handleExpandChange = (panel) => (event, isExpanded) => {
+  const handleExpandChange = (panel) => (e, isExpanded) => {
     setExpanded(isExpanded ? panel : false);
   };
+
+  const inputWidth = '60px';
 
 
   // const [lineDotSize, setLineDotSize] = useState(4);
@@ -44,15 +46,143 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
       <div className="font-bold text-white">
         ここにリスト
       </div>
-      <WrappedAccordion panel='panel3' title='test!' children expanded={expanded} handleChange={handleExpandChange} >
-        <div>なかみ！</div>
+      <WrappedAccordion panel='temperature' title='気温（折れ線）' children expanded={expanded} handleChange={handleExpandChange} >
+        <label htmlFor="lineColorInput">折れ線色</label>
+        <input 
+          id="lineColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="lineWidthInput">折れ線幅</label>
+        <input 
+          id="lineWidthInput"
+          type='number'
+          step={0.1} 
+          value={0}
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="dotOutlineColorInput">ドット輪郭色</label>
+        <input 
+          id="dotOutlineColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="dotFillColorInput">ドット塗り色</label>
+        <input 
+          id="dotFillColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="dotSizeInput">ドットサイズ</label>
+        <input 
+          id="dotSizeInput"
+          type='number'
+          step={0.5} 
+          value={lineDotSize}
+          onChange={handleInputChange}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="dotOutlineWidthInput">ドット輪郭幅</label>
+        <input 
+          id="dotOutlineWidthInput"
+          type='number'
+          step={0.1} 
+          value={1}
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="tempMaxValue">目盛り最大値</label>
+        <input 
+        id="tempMaxValue"
+        type='number'
+        step={10} 
+        value={30}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="tempMinValue">目盛り最小値</label>
+        <input 
+        id="tempMinValue"
+        type='number'
+        step={10} 
+        value={-30}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="tempScaleCount">目盛り線の数</label>
+        <input 
+        id="tempScaleCount"
+        type='number'
+        step={1} 
+        value={8}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="tempYAxisFontSize">目盛り文字サイズ</label>
+        <input 
+        id="tempYAxisFontSize"
+        type='number'
+        step={1} 
+        value={12}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="tempYAxisFontColor">目盛り文字色</label>
+        <input 
+          id="tempYAxisFontColor"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="tempYAxisLineWidth">縦軸線幅</label>
+        <input 
+        id="tempYAxisLineWidth"
+        type='number'
+        step={0.1} 
+        value={0.5}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="tempYAxisLineColor">縦軸線幅</label>
+        <input 
+          id="tempYAxisLineColor"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
       </ WrappedAccordion>
 
-      <WrappedAccordion panel='panel4' title='test2!' children expanded={expanded} handleChange={handleExpandChange} >
-        <div>なかみ２！</div>
+      <WrappedAccordion panel='layout' title='レイアウト' children expanded={expanded} handleChange={handleExpandChange} >
+        <label htmlFor="dotSizeInput">DotSize</label>
+        <input 
+          id="dotSizeInput"
+          type='number' 
+          step={0.5} 
+          value={lineDotSize} 
+          onChange={handleInputChange}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="dotSizeInput">DotSize</label>
+        <input 
+          id="dotSizeInput"
+          type='number' 
+          step={0.5} 
+          value={lineDotSize} 
+          onChange={handleInputChange}
+          style={{ width: inputWidth }}/>
       </ WrappedAccordion>
 
-      <Accordion 
+
+
+      {/* <Accordion 
         expanded={expanded === 'panel1'} 
         onChange={handleExpandChange('panel1')} 
         disableGutters={true} //開いた時のギャップをなくす
@@ -64,7 +194,6 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
           },
         }} >
         <AccordionSummary  //アコーディオンのヘッダー
-          // expandIcon={<ExpandMoreIcon />}
           aria-controls="panel1bh-content"
           id="panel1bh-header"
           sx={{ backgroundColor: 'darkgreen'}}
@@ -84,10 +213,10 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
               style={{ width: '100px' }}/>
           </div>
         </AccordionDetails>
-      </Accordion>
+      </Accordion> */}
       
       {/* ここから2つめ */}
-      <Accordion 
+      {/* <Accordion 
         expanded={expanded === 'panel2'} 
         onChange={handleExpandChange('panel2')} 
         disableGutters={true} //開いた時のギャップをなくす
@@ -99,7 +228,6 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
           },
         }} >
         <AccordionSummary  //アコーディオンのヘッダー
-          // expandIcon={<ExpandMoreIcon />}
           aria-controls="panel2bh-content"
           id="panel2bh-header"
           sx={{ backgroundColor: 'darkgreen'}}
@@ -113,7 +241,7 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
             Aliquam eget maximus est, id dignissim quam.
           </Typography>
         </AccordionDetails>
-      </Accordion>
+      </Accordion> */}
     </div>
   )
 }

--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -1,6 +1,16 @@
 import React, { useState } from "react";
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Typography from '@mui/material/Typography';
 
 export default function GraphSettings({ lineDotSize, handleValueChange }) {
+  const [expanded, setExpanded] = React.useState(false);
+  const handleChange = (panel) => (event, isExpanded) => {
+    setExpanded(isExpanded ? panel : false);
+  };
+
+
   // const [lineDotSize, setLineDotSize] = useState(4);
   // const [barStrokeWidth, setBarStrokeWidth] = useState(1);
   // const [tempDomainMax, setTempDomainMax] = useState(40);
@@ -32,6 +42,80 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
         ここにリスト
       </div>
 
+      <div>
+        <Accordion expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
+          <AccordionSummary
+            // expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1bh-content"
+            id="panel1bh-header"
+            >
+            <Typography sx={{ width: '33%', flexShrink: 0 }}>
+              General settings
+            </Typography>
+            <Typography sx={{ color: 'text.secondary' }}>I am an accordion</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>
+              Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat.
+              Aliquam eget maximus est, id dignissim quam.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Accordion expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
+          <AccordionSummary
+            // expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel2bh-content"
+            id="panel2bh-header"
+          >
+            <Typography sx={{ width: '33%', flexShrink: 0 }}>Users</Typography>
+            <Typography sx={{ color: 'text.secondary' }}>
+              You are currently not an owner
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>
+              Donec placerat, lectus sed mattis semper, neque lectus feugiat lectus,
+              varius pulvinar diam eros in elit. Pellentesque convallis laoreet
+              laoreet.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Accordion expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
+          <AccordionSummary
+            // expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel3bh-content"
+            id="panel3bh-header"
+          >
+            <Typography sx={{ width: '33%', flexShrink: 0 }}>
+              Advanced settings
+            </Typography>
+            <Typography sx={{ color: 'text.secondary' }}>
+              Filtering has been entirely disabled for whole web server
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>
+              Nunc vitae orci ultricies, auctor nunc in, volutpat nisl. Integer sit
+              amet egestas eros, vitae egestas augue. Duis vel est augue.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Accordion expanded={expanded === 'panel4'} onChange={handleChange('panel4')}>
+          <AccordionSummary
+            // expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel4bh-content"
+            id="panel4bh-header"
+          >
+            <Typography sx={{ width: '33%', flexShrink: 0 }}>Personal data</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>
+              Nunc vitae orci ultricies, auctor nunc in, volutpat nisl. Integer sit
+              amet egestas eros, vitae egestas augue. Duis vel est augue.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+      </div>
     </div>
   )
 }

--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -65,10 +65,16 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
             <div font-3xl> レイアウト </div>
           </AccordionSummary>
           <AccordionDetails>
-            <Typography sx={{marginLeft: '10px' }}>
-              Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat.
-              Aliquam eget maximus est, id dignissim quam.
-            </Typography>
+            <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
+              <label htmlFor="dotSizeInput">DotSize</label>
+              <input 
+                id="dotSizeInput"
+                type='number' 
+                step={0.5} 
+                value={lineDotSize} 
+                onChange={handleInputChange}
+                style={{ width: '100px' }}/>
+            </div>
           </AccordionDetails>
         </Accordion>
         

--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -4,6 +4,7 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Typography from '@mui/material/Typography';
 
+
 export default function GraphSettings({ lineDotSize, handleValueChange }) {
   const [expanded, setExpanded] = React.useState(false);
   const handleChange = (panel) => (event, isExpanded) => {
@@ -43,25 +44,68 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
       </div>
 
       <div>
-        <Accordion expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
-          <AccordionSummary
+        <Accordion 
+          expanded={expanded === 'panel1'} 
+          onChange={handleChange('panel1')} 
+          disableGutters={true} //開いた時のギャップをなくす
+          elevation={0} //影をなくす
+          sx={{
+            '&.MuiAccordion-root': {
+              borderRadius: 0,
+              backgroundColor: 'limegreen',
+            },
+          }} >
+          <AccordionSummary  //アコーディオンのヘッダー
             // expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel1bh-content"
-            id="panel1bh-header"
+            aria-controls="panel2bh-content"
+            id="panel2bh-header"
+            sx={{ backgroundColor: 'darkgreen'}}
+
             >
-            <Typography sx={{ width: '33%', flexShrink: 0 }}>
-              General settings
-            </Typography>
-            <Typography sx={{ color: 'text.secondary' }}>I am an accordion</Typography>
+            <div font-3xl> レイアウト </div>
           </AccordionSummary>
           <AccordionDetails>
-            <Typography>
+            <Typography sx={{marginLeft: '10px' }}>
               Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat.
               Aliquam eget maximus est, id dignissim quam.
             </Typography>
           </AccordionDetails>
         </Accordion>
-        <Accordion expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
+        
+        {/* ここから2つめ */}
+        <Accordion 
+          expanded={expanded === 'panel2'} 
+          onChange={handleChange('panel2')} 
+          disableGutters={true} //開いた時のギャップをなくす
+          elevation={0} //影をなくす
+          sx={{
+            '&.MuiAccordion-root': {
+              borderRadius: 0,
+              backgroundColor: 'limegreen',
+            },
+          }} >
+          <AccordionSummary  //アコーディオンのヘッダー
+            // expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel2bh-content"
+            id="panel2bh-header"
+            sx={{ backgroundColor: 'darkgreen'}}
+
+            >
+            <div font-3xl> 気温（折れ線） </div>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography sx={{marginLeft: '10px' }}>
+              Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat.
+              Aliquam eget maximus est, id dignissim quam.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+
+
+
+
+
+        {/* <Accordion expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
           <AccordionSummary
             // expandIcon={<ExpandMoreIcon />}
             aria-controls="panel2bh-content"
@@ -114,7 +158,7 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
               amet egestas eros, vitae egestas augue. Duis vel est augue.
             </Typography>
           </AccordionDetails>
-        </Accordion>
+        </Accordion> */}
       </div>
     </div>
   )

--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -9,7 +9,7 @@ import WrappedAccordion from "./wrapped_accordion";
 
 export default function GraphSettings({ lineDotSize, handleValueChange }) {
   const [expanded, setExpanded] = useState(false);
-  const handleChange = (panel) => (event, isExpanded) => {
+  const handleExpandChange = (panel) => (event, isExpanded) => {
     setExpanded(isExpanded ? panel : false);
   };
 
@@ -44,17 +44,17 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
       <div className="font-bold text-white">
         ここにリスト
       </div>
-      <WrappedAccordion panel='panel3' title='test!' children expanded={expanded} handleChange={handleChange} >
+      <WrappedAccordion panel='panel3' title='test!' children expanded={expanded} handleChange={handleExpandChange} >
         <div>なかみ！</div>
       </ WrappedAccordion>
 
-      <WrappedAccordion panel='panel4' title='test2!' children expanded={expanded} handleChange={handleChange} >
+      <WrappedAccordion panel='panel4' title='test2!' children expanded={expanded} handleChange={handleExpandChange} >
         <div>なかみ２！</div>
       </ WrappedAccordion>
 
       <Accordion 
         expanded={expanded === 'panel1'} 
-        onChange={handleChange('panel1')} 
+        onChange={handleExpandChange('panel1')} 
         disableGutters={true} //開いた時のギャップをなくす
         elevation={0} //影をなくす
         sx={{
@@ -89,7 +89,7 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
       {/* ここから2つめ */}
       <Accordion 
         expanded={expanded === 'panel2'} 
-        onChange={handleChange('panel2')} 
+        onChange={handleExpandChange('panel2')} 
         disableGutters={true} //開いた時のギャップをなくす
         elevation={0} //影をなくす
         sx={{

--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -98,150 +98,293 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
           onChange={""}
           style={{ width: inputWidth }}/>
 
-        <label htmlFor="tempMaxValue">目盛り最大値</label>
+        <label htmlFor="tempMaxInput">目盛り最大値</label>
         <input 
-        id="tempMaxValue"
+        id="tempMaxInput"
         type='number'
         step={10} 
-        value={30}
+        value={40}
         onChange={""}
         style={{ width: inputWidth }}/>
 
-        <label htmlFor="tempMinValue">目盛り最小値</label>
+        <label htmlFor="tempMinInput">目盛り最小値</label>
         <input 
-        id="tempMinValue"
+        id="tempMinInput"
         type='number'
         step={10} 
         value={-30}
         onChange={""}
         style={{ width: inputWidth }}/>
 
-        <label htmlFor="tempScaleCount">目盛り線の数</label>
+        <label htmlFor="tempScaleCountInput">目盛り線の数</label>
         <input 
-        id="tempScaleCount"
+        id="tempScaleCountInput"
         type='number'
         step={1} 
         value={8}
         onChange={""}
         style={{ width: inputWidth }}/>
 
-        <label htmlFor="tempYAxisFontSize">目盛り文字サイズ</label>
+        <label htmlFor="tempYAxisFontSizeInput">目盛り文字サイズ</label>
         <input 
-        id="tempYAxisFontSize"
+        id="tempYAxisFontSizeInput"
         type='number'
         step={1} 
         value={12}
         onChange={""}
         style={{ width: inputWidth }}/>
 
-        <label htmlFor="tempYAxisFontColor">目盛り文字色</label>
+        <label htmlFor="tempYAxisFontColorInput">目盛り文字色</label>
         <input 
-          id="tempYAxisFontColor"
+          id="tempYAxisFontColorInput"
           type='color' 
           value={''} 
           onChange={""}
           style={{ width: inputWidth }}/>
 
-        <label htmlFor="tempYAxisLineWidth">縦軸線幅</label>
+        <label htmlFor="tempYAxisLineWidthInput">縦軸線幅</label>
         <input 
-        id="tempYAxisLineWidth"
+        id="tempYAxisLineWidthInput"
         type='number'
         step={0.1} 
         value={0.5}
         onChange={""}
         style={{ width: inputWidth }}/>
 
-        <label htmlFor="tempYAxisLineColor">縦軸線幅</label>
+        <label htmlFor="tempYAxisLineColorInput">縦軸線色</label>
         <input 
-          id="tempYAxisLineColor"
+          id="tempYAxisLineColorInput"
           type='color' 
           value={''} 
           onChange={""}
           style={{ width: inputWidth }}/>
       </ WrappedAccordion>
 
+      <WrappedAccordion panel='rainfall' title='降水量（棒）' children expanded={expanded} handleChange={handleExpandChange} >
+        <label htmlFor="barFillColorInput">塗り色</label>
+        <input 
+          id="barFillColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="barOutlineColorInput">輪郭色</label>
+        <input 
+          id="barOutlineColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="lineWidthInput">棒幅</label>
+        <input 
+          id="lineWidthInput"
+          type='number'
+          step={5} 
+          value={30}
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        
+        <label htmlFor="barOutlineWidthInput">輪郭幅</label>
+        <input 
+          id="barOutlineWidthInput"
+          type='number'
+          step={0.1} 
+          value={1}
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="rainMaxInput">目盛り最大値</label>
+        <input 
+        id="tempMaxInput"
+        type='number'
+        step={50} 
+        value={700}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="rainScaleCountInput">目盛り線の数</label>
+        <input 
+        id="rainScaleCountInput"
+        type='number'
+        step={1} 
+        value={8}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="rainYAxisFontSizeInput">目盛り文字サイズ</label>
+        <input 
+        id="rainYAxisFontSizeInput"
+        type='number'
+        step={1} 
+        value={12}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="rainYAxisFontColorInput">目盛り文字色</label>
+        <input 
+          id="rainYAxisFontColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="rainYAxisLineWidthInput">縦軸線幅</label>
+        <input 
+        id="rainYAxisLineWidthInput"
+        type='number'
+        step={0.1} 
+        value={0.5}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="rainYAxisLineColorInput">縦軸線色</label>
+        <input 
+          id="rainYAxisLineColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+      </WrappedAccordion>
+
+      <WrappedAccordion panel='month' title='横軸（月）' children expanded={expanded} handleChange={handleExpandChange} >
+      <label htmlFor="xAxisFontSizeInput">文字サイズ</label>
+        <input 
+        id="xAxisFontSizeInput"
+        type='number'
+        step={1} 
+        value={12}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="xAxisFontColorInput">文字色</label>
+        <input 
+          id="xAxisFontColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+
+        <label htmlFor="xAxisLineWidthInput">軸線幅</label>
+        <input 
+        id="xAxisLineWidthInput"
+        type='number'
+        step={0.1} 
+        value={0.5}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="xAxisLineColorInput">軸線色</label>
+        <input 
+          id="xAxisLineColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+      </WrappedAccordion>
+
+      <WrappedAccordion panel='title' title='タイトル' children expanded={expanded} handleChange={handleExpandChange} >
+        <label htmlFor="titleFontSizeInput">文字サイズ</label>
+        <input 
+        id="titleFontSizeInput"
+        type='number'
+        step={1} 
+        value={12}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="titleFontColorInput">文字色</label>
+        <input 
+          id="titleFontColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
+          style={{ width: inputWidth }}/>
+      </WrappedAccordion>
+
       <WrappedAccordion panel='layout' title='レイアウト' children expanded={expanded} handleChange={handleExpandChange} >
-        <label htmlFor="dotSizeInput">DotSize</label>
+      <label htmlFor="layoutHeightInput">縦幅</label>
         <input 
-          id="dotSizeInput"
-          type='number' 
-          step={0.5} 
-          value={lineDotSize} 
-          onChange={handleInputChange}
-          style={{ width: inputWidth }}/>
+        id="layoutHeightInput"
+        type='number'
+        step={10} 
+        value={500}
+        onChange={""}
+        style={{ width: inputWidth }}/>
 
-        <label htmlFor="dotSizeInput">DotSize</label>
+        <label htmlFor="layoutWidthInput">横幅</label>
         <input 
-          id="dotSizeInput"
-          type='number' 
-          step={0.5} 
-          value={lineDotSize} 
-          onChange={handleInputChange}
+        id="layoutHeightInput"
+        type='number'
+        step={10} 
+        value={500}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="marginTopInput">上余白</label>
+        <input 
+        id="marginTopInput"
+        type='number'
+        step={5} 
+        value={50}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="marginBottomInput">下余白</label>
+        <input 
+        id="marginBottomInput"
+        type='number'
+        step={5} 
+        value={60}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="marginLeftInput">左余白</label>
+        <input 
+        id="marginLeftInput"
+        type='number'
+        step={5} 
+        value={20}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="marginRightInput">右余白</label>
+        <input 
+        id="marginRightInput"
+        type='number'
+        step={5} 
+        value={20}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="marginTopInput">上余白</label>
+        <input 
+        id="marginTopInput"
+        type='number'
+        step={5} 
+        value={50}
+        onChange={""}
+        style={{ width: inputWidth }}/>
+
+        <label htmlFor="backgroundColorInput">背景色</label>
+        <input 
+          id="backgroundColorInput"
+          type='color' 
+          value={''} 
+          onChange={""}
           style={{ width: inputWidth }}/>
+        
+        <label htmlFor="fontfamilySelect">文字フォント</label>
+        <select 
+          id="fontfamilySelect"
+          onChange={""}
+          style={{ width: '100px', justifySelf: 'end' }}>
+          <option value="sans-serif">ゴシック体</option>
+          <option value="serif">明朝体</option>
+        </select>
       </ WrappedAccordion>
-
-
-
-      {/* <Accordion 
-        expanded={expanded === 'panel1'} 
-        onChange={handleExpandChange('panel1')} 
-        disableGutters={true} //開いた時のギャップをなくす
-        elevation={0} //影をなくす
-        sx={{
-          '&.MuiAccordion-root': {
-            borderRadius: 0,
-            backgroundColor: 'limegreen',
-          },
-        }} >
-        <AccordionSummary  //アコーディオンのヘッダー
-          aria-controls="panel1bh-content"
-          id="panel1bh-header"
-          sx={{ backgroundColor: 'darkgreen'}}
-
-          >
-          <div font-3xl> レイアウト </div>
-        </AccordionSummary>
-        <AccordionDetails>
-          <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
-            <label htmlFor="dotSizeInput">DotSize</label>
-            <input 
-              id="dotSizeInput"
-              type='number' 
-              step={0.5} 
-              value={lineDotSize} 
-              onChange={handleInputChange}
-              style={{ width: '100px' }}/>
-          </div>
-        </AccordionDetails>
-      </Accordion> */}
-      
-      {/* ここから2つめ */}
-      {/* <Accordion 
-        expanded={expanded === 'panel2'} 
-        onChange={handleExpandChange('panel2')} 
-        disableGutters={true} //開いた時のギャップをなくす
-        elevation={0} //影をなくす
-        sx={{
-          '&.MuiAccordion-root': {
-            borderRadius: 0,
-            backgroundColor: 'limegreen',
-          },
-        }} >
-        <AccordionSummary  //アコーディオンのヘッダー
-          aria-controls="panel2bh-content"
-          id="panel2bh-header"
-          sx={{ backgroundColor: 'darkgreen'}}
-
-          >
-          <div font-3xl> 気温（折れ線） </div>
-        </AccordionSummary>
-        <AccordionDetails>
-          <Typography sx={{marginLeft: '10px' }}>
-            Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat.
-            Aliquam eget maximus est, id dignissim quam.
-          </Typography>
-        </AccordionDetails>
-      </Accordion> */}
     </div>
   )
 }

--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -17,7 +17,7 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
   }
 
   return (
-    <>
+    <div className="container">
       <div id="input">
         <div>DotSize</div>
         <input 
@@ -28,6 +28,10 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
         <p>ここはGraphSettingsの中: {lineDotSize} </p>  
       </div>
 
-    </>
+      <div className="font-bold text-white">
+        ここにリスト
+      </div>
+
+    </div>
   )
 }

--- a/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/graph_settings.jsx
@@ -4,9 +4,11 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Typography from '@mui/material/Typography';
 
+import WrappedAccordion from "./wrapped_accordion";
+
 
 export default function GraphSettings({ lineDotSize, handleValueChange }) {
-  const [expanded, setExpanded] = React.useState(false);
+  const [expanded, setExpanded] = useState(false);
   const handleChange = (panel) => (event, isExpanded) => {
     setExpanded(isExpanded ? panel : false);
   };
@@ -42,130 +44,76 @@ export default function GraphSettings({ lineDotSize, handleValueChange }) {
       <div className="font-bold text-white">
         ここにリスト
       </div>
+      <WrappedAccordion panel='panel3' title='test!' children expanded={expanded} handleChange={handleChange} >
+        <div>なかみ！</div>
+      </ WrappedAccordion>
 
-      <div>
-        <Accordion 
-          expanded={expanded === 'panel1'} 
-          onChange={handleChange('panel1')} 
-          disableGutters={true} //開いた時のギャップをなくす
-          elevation={0} //影をなくす
-          sx={{
-            '&.MuiAccordion-root': {
-              borderRadius: 0,
-              backgroundColor: 'limegreen',
-            },
-          }} >
-          <AccordionSummary  //アコーディオンのヘッダー
-            // expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel2bh-content"
-            id="panel2bh-header"
-            sx={{ backgroundColor: 'darkgreen'}}
+      <WrappedAccordion panel='panel4' title='test2!' children expanded={expanded} handleChange={handleChange} >
+        <div>なかみ２！</div>
+      </ WrappedAccordion>
 
-            >
-            <div font-3xl> レイアウト </div>
-          </AccordionSummary>
-          <AccordionDetails>
-            <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
-              <label htmlFor="dotSizeInput">DotSize</label>
-              <input 
-                id="dotSizeInput"
-                type='number' 
-                step={0.5} 
-                value={lineDotSize} 
-                onChange={handleInputChange}
-                style={{ width: '100px' }}/>
-            </div>
-          </AccordionDetails>
-        </Accordion>
-        
-        {/* ここから2つめ */}
-        <Accordion 
-          expanded={expanded === 'panel2'} 
-          onChange={handleChange('panel2')} 
-          disableGutters={true} //開いた時のギャップをなくす
-          elevation={0} //影をなくす
-          sx={{
-            '&.MuiAccordion-root': {
-              borderRadius: 0,
-              backgroundColor: 'limegreen',
-            },
-          }} >
-          <AccordionSummary  //アコーディオンのヘッダー
-            // expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel2bh-content"
-            id="panel2bh-header"
-            sx={{ backgroundColor: 'darkgreen'}}
+      <Accordion 
+        expanded={expanded === 'panel1'} 
+        onChange={handleChange('panel1')} 
+        disableGutters={true} //開いた時のギャップをなくす
+        elevation={0} //影をなくす
+        sx={{
+          '&.MuiAccordion-root': {
+            borderRadius: 0,
+            backgroundColor: 'limegreen',
+          },
+        }} >
+        <AccordionSummary  //アコーディオンのヘッダー
+          // expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1bh-content"
+          id="panel1bh-header"
+          sx={{ backgroundColor: 'darkgreen'}}
 
-            >
-            <div font-3xl> 気温（折れ線） </div>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography sx={{marginLeft: '10px' }}>
-              Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat.
-              Aliquam eget maximus est, id dignissim quam.
-            </Typography>
-          </AccordionDetails>
-        </Accordion>
-
-
-
-
-
-        {/* <Accordion expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
-          <AccordionSummary
-            // expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel2bh-content"
-            id="panel2bh-header"
           >
-            <Typography sx={{ width: '33%', flexShrink: 0 }}>Users</Typography>
-            <Typography sx={{ color: 'text.secondary' }}>
-              You are currently not an owner
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography>
-              Donec placerat, lectus sed mattis semper, neque lectus feugiat lectus,
-              varius pulvinar diam eros in elit. Pellentesque convallis laoreet
-              laoreet.
-            </Typography>
-          </AccordionDetails>
-        </Accordion>
-        <Accordion expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
-          <AccordionSummary
-            // expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel3bh-content"
-            id="panel3bh-header"
+          <div font-3xl> レイアウト </div>
+        </AccordionSummary>
+        <AccordionDetails>
+          <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
+            <label htmlFor="dotSizeInput">DotSize</label>
+            <input 
+              id="dotSizeInput"
+              type='number' 
+              step={0.5} 
+              value={lineDotSize} 
+              onChange={handleInputChange}
+              style={{ width: '100px' }}/>
+          </div>
+        </AccordionDetails>
+      </Accordion>
+      
+      {/* ここから2つめ */}
+      <Accordion 
+        expanded={expanded === 'panel2'} 
+        onChange={handleChange('panel2')} 
+        disableGutters={true} //開いた時のギャップをなくす
+        elevation={0} //影をなくす
+        sx={{
+          '&.MuiAccordion-root': {
+            borderRadius: 0,
+            backgroundColor: 'limegreen',
+          },
+        }} >
+        <AccordionSummary  //アコーディオンのヘッダー
+          // expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel2bh-content"
+          id="panel2bh-header"
+          sx={{ backgroundColor: 'darkgreen'}}
+
           >
-            <Typography sx={{ width: '33%', flexShrink: 0 }}>
-              Advanced settings
-            </Typography>
-            <Typography sx={{ color: 'text.secondary' }}>
-              Filtering has been entirely disabled for whole web server
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography>
-              Nunc vitae orci ultricies, auctor nunc in, volutpat nisl. Integer sit
-              amet egestas eros, vitae egestas augue. Duis vel est augue.
-            </Typography>
-          </AccordionDetails>
-        </Accordion>
-        <Accordion expanded={expanded === 'panel4'} onChange={handleChange('panel4')}>
-          <AccordionSummary
-            // expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel4bh-content"
-            id="panel4bh-header"
-          >
-            <Typography sx={{ width: '33%', flexShrink: 0 }}>Personal data</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography>
-              Nunc vitae orci ultricies, auctor nunc in, volutpat nisl. Integer sit
-              amet egestas eros, vitae egestas augue. Duis vel est augue.
-            </Typography>
-          </AccordionDetails>
-        </Accordion> */}
-      </div>
+          <div font-3xl> 気温（折れ線） </div>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography sx={{marginLeft: '10px' }}>
+            Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat.
+            Aliquam eget maximus est, id dignissim quam.
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
     </div>
   )
 }

--- a/app/javascript/react/canvas/components/graph_settings/wrapped_accordion.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/wrapped_accordion.jsx
@@ -3,59 +3,41 @@ import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 
-export default function WrappedAccordion({ expanded, panel, title, children, handleChange }) {
-
+export default function WrappedAccordion({ 
+  expanded, //親コンポーネントのstate。開いているパネルの名前が入る 
+  panel,    //このアコーディオンのpanel名（panel1, panel2, ...）
+  title,    //アコーディオンのタイトル
+  children, handleChange }) {
   return (
-    <>
-      <Accordion
-        expanded={expanded === panel} 
-        onChange={handleChange(panel)} 
-        disableGutters={true}
-        elevation={0}
-        sx={{
-          '&.MuiAccordion-root': {
-            borderRadius: 0,
-            backgroundColor: 'limegreen',
-          },
-        }} >
-        <AccordionSummary
-          aria-controls= {`${panel}bh-content`}
-          id={`${panel}bh-header`}
-          sx={{ backgroundColor: 'darkgreen'}}
-          >
-          <div font-3xl>{title}</div>
-        </AccordionSummary>
-        <AccordionDetails>
-          <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
-            { children }
-          </div>
-        </AccordionDetails>
-      </Accordion>
-      {/* <Accordion 
-      //   expanded={expanded === panel} 
-      //   // onChange={handleChange(panel)} 
-      //   disableGutters={true} //開いた時のギャップをなくす
-      //   elevation={0} //影をなくす
-      //   sx={{
-      //     '&.MuiAccordion-root': {
-      //       borderRadius: 0,
-      //       backgroundColor: 'limegreen',
-      //     },
-      //   }} >
-      //   <AccordionSummary  //アコーディオンのヘッダー
-      //     // expandIcon={<ExpandMoreIcon />}
-      //     aria-controls= {`${panel}bh-content`}
-      //     id={`${panel}bh-header`}
-      //     sx={{ backgroundColor: 'darkgreen'}}
-      //     >
-      //     <div font-3xl>{title}</div>
-      //   </AccordionSummary>
-      //   <AccordionDetails>
-      //     <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
-      //       { children }
-      //     </div>
-      //   </AccordionDetails>
-      // </Accordion> */}
-    </>
+    <Accordion
+      expanded={expanded === panel} 
+      onChange={handleChange(panel)} //親コントローラーのhandleExpandChangeを呼び出す
+      disableGutters={true}          //開いた時のギャップをなくす
+      elevation={0}                  //影をなくす
+      sx={{
+        '&.MuiAccordion-root': {
+          borderRadius: 0,
+          backgroundColor: 'limegreen',
+        },
+      }} >
+      <AccordionSummary
+        aria-controls= {`${panel}bh-content`}
+        id={`${panel}bh-header`}
+        sx={{ backgroundColor: 'darkgreen'}}
+        >
+
+        {/* ここにタイトル */}
+        <div font-3xl>{title}</div>
+      
+      </AccordionSummary>
+      <AccordionDetails>
+        <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
+          
+          {/* ここに中身が入る */}
+          { children }
+
+        </div>
+      </AccordionDetails>
+    </Accordion>
   )
 }

--- a/app/javascript/react/canvas/components/graph_settings/wrapped_accordion.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/wrapped_accordion.jsx
@@ -5,7 +5,7 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 
 export default function WrappedAccordion({ 
   expanded, //親コンポーネントのstate。開いているパネルの名前が入る 
-  panel,    //このアコーディオンのpanel名（panel1, panel2, ...）
+  panel,    //このアコーディオンのpanel名（ユニークな名前にする）
   title,    //アコーディオンのタイトル
   children, handleChange }) {
   return (
@@ -31,7 +31,7 @@ export default function WrappedAccordion({
       
       </AccordionSummary>
       <AccordionDetails>
-        <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'auto 60px', gap: '10px' }}>
           
           {/* ここに中身が入る */}
           { children }

--- a/app/javascript/react/canvas/components/graph_settings/wrapped_accordion.jsx
+++ b/app/javascript/react/canvas/components/graph_settings/wrapped_accordion.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+
+export default function WrappedAccordion({ expanded, panel, title, children, handleChange }) {
+
+  return (
+    <>
+      <Accordion
+        expanded={expanded === panel} 
+        onChange={handleChange(panel)} 
+        disableGutters={true}
+        elevation={0}
+        sx={{
+          '&.MuiAccordion-root': {
+            borderRadius: 0,
+            backgroundColor: 'limegreen',
+          },
+        }} >
+        <AccordionSummary
+          aria-controls= {`${panel}bh-content`}
+          id={`${panel}bh-header`}
+          sx={{ backgroundColor: 'darkgreen'}}
+          >
+          <div font-3xl>{title}</div>
+        </AccordionSummary>
+        <AccordionDetails>
+          <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
+            { children }
+          </div>
+        </AccordionDetails>
+      </Accordion>
+      {/* <Accordion 
+      //   expanded={expanded === panel} 
+      //   // onChange={handleChange(panel)} 
+      //   disableGutters={true} //開いた時のギャップをなくす
+      //   elevation={0} //影をなくす
+      //   sx={{
+      //     '&.MuiAccordion-root': {
+      //       borderRadius: 0,
+      //       backgroundColor: 'limegreen',
+      //     },
+      //   }} >
+      //   <AccordionSummary  //アコーディオンのヘッダー
+      //     // expandIcon={<ExpandMoreIcon />}
+      //     aria-controls= {`${panel}bh-content`}
+      //     id={`${panel}bh-header`}
+      //     sx={{ backgroundColor: 'darkgreen'}}
+      //     >
+      //     <div font-3xl>{title}</div>
+      //   </AccordionSummary>
+      //   <AccordionDetails>
+      //     <div style={{ display: 'grid', gridTemplateColumns: 'auto 100px', gap: '10px' }}>
+      //       { children }
+      //     </div>
+      //   </AccordionDetails>
+      // </Accordion> */}
+    </>
+  )
+}

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -8,7 +8,7 @@ import Graph from './graph/graph';
 import GraphSettings from './graph_settings/graph_settings';
 
 
-const drawerWidth = 280;
+const drawerWidth = 300;
 
 const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
   ({ theme, open }) => ({

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -8,7 +8,7 @@ import Graph from './graph/graph';
 import GraphSettings from './graph_settings/graph_settings';
 
 
-const drawerWidth = 240;
+const drawerWidth = 280;
 
 const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
   ({ theme, open }) => ({
@@ -36,7 +36,7 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
 );
 
 export default function MainWithRightDrawer() {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
 
   const handleDrawerOpen = () => {
     setOpen(true);
@@ -67,37 +67,39 @@ export default function MainWithRightDrawer() {
         </div>
 
       </Main>
-        <Drawer
-          sx={{
-            position: 'relative',
-            marginLeft: "auto",
+      <Drawer
+        sx={{
+          position: 'relative',
+          marginLeft: "auto",
+          width: drawerWidth,
+          "& .MuiBackdrop-root": {
+            display: "none"
+          },
+          "& .MuiDrawer-paper": {
             width: drawerWidth,
-            "& .MuiBackdrop-root": {
-              display: "none"
-            },
-            "& .MuiDrawer-paper": {
-              width: drawerWidth,
-              height: "100%",
-              position: "absolute",
-              backgroundColor: "limegreen",
-            }
-          }}
-          // className={[classes.drawer, 'text-3xl']}
-          variant="persistent"
-          anchor="right"
-          open={open}
-        > 
-          {/* ここからDrawerの中身 */}
-          <div width='100%' height='100%' className='bg-red'>
-            <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
-            <div className='font-bold'>これはドロワーの中身です</div>
-          </div>
+            height: "100%",
+            position: "absolute",
+            backgroundColor: "limegreen",
+            display: "flex",
+            padding: "20px",
+            alignItems: "center",
+          }
+        }}
+        // className={[classes.drawer, 'text-3xl']}
+        variant="persistent"
+        anchor="right"
+        open={open}
+      > 
+        {/* ここからDrawerの中身 */}
+        <div>
+          <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
+        </div>
 
-          {/* ここにグラフ設定値入力コンポーネント */}
-          <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/>
-          <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div>
+        {/* ここにグラフ設定値入力コンポーネント */}
+        <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/>
+        {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
 
-        </Drawer>
+      </Drawer>
     </Box>
   );
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -16,6 +16,8 @@ export default function CanvasApp() {
       </div> */}
       <MainWithRightDrawer />
       <BottomDrawer />
+
+      
     </div>
   )
 }

--- a/app/javascript/react/entrypoints/test_entry.jsx
+++ b/app/javascript/react/entrypoints/test_entry.jsx
@@ -14,6 +14,37 @@ function Test() {
       <StyledEngineProvider injectFirst>
         <BottomDrawer />
       </StyledEngineProvider>
+
+      {/* アコーディオン */}
+      <div className="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" defaultChecked /> 
+        <div className="collapse-title text-xl font-medium">
+          Click to open this one and close others
+        </div>
+        <div className="collapse-content"> 
+          <p>hello</p>
+        </div>
+      </div>
+      <div className="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" /> 
+        <div className="collapse-title text-xl font-medium">
+          Click to open this one and close others
+        </div>
+        <div className="collapse-content"> 
+          <p>hello</p>
+        </div>
+      </div>
+      <div className="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" /> 
+        <div className="collapse-title text-xl font-medium">
+          Click to open this one and close others
+        </div>
+        <div className="collapse-content"> 
+          <p>hello</p>
+        </div>
+      </div>
+
+
     </>
   );
 }


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/45

- MaterialUIのAccordionを使って，項目ごとにまとめています
- Accordionのレイアウトを独自にアレンジしています
- Accordionをラップするコンポーネントを作成し，その中にchildrenとしてlabelとinputの組み合わせを複数入れました
- children部分もコンポーネントに切り分けたほうが見通しが良くなりますが，別issueに分けて一旦これで完成とします。


https://i.gyazo.com/dd91e7deac3854d5fa5d127c50abc356.gif

close #45 