### PR TITLE
tailwind.config.jsにfontFamilyのデフォルトを設定

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,14 @@
 const withMT = require("@material-tailwind/react/utils/withMT");
 
 module.exports = withMT({
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Helvetica', 'Arial', 'sans-serif'],
+        serif: ['Merriweather', 'serif'],
+        },
+      },
+    },
   content: [
     './app/views/**/*.html.erb',
     './app/views/**/*.html.slim',


### PR DESCRIPTION
ビルドでエラーが発生したので，次のデフォルト値を記載した

```
module.exports = withMT({
  theme: {
    extend: {
      fontFamily: {
        sans: ['Helvetica', 'Arial', 'sans-serif'],
        serif: ['Merriweather', 'serif'],
        },
      },
    },
  content: [　　〜〜〜〜〜〜
```