### PR TITLE
画面のグラフ設定値をバックエンドと連携する

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,2 @@
+class Api::BaseController < ActionController::API
+end

--- a/app/controllers/api/graphs_controller.rb
+++ b/app/controllers/api/graphs_controller.rb
@@ -1,0 +1,2 @@
+class Api::GraphsController < Api::BaseController
+end

--- a/app/controllers/api/graphs_controller.rb
+++ b/app/controllers/api/graphs_controller.rb
@@ -11,4 +11,20 @@ class Api::GraphsController < Api::BaseController
     graph = Graph.find(params[:id])
     render json: { graph: graph, graph_setting: graph.graph_setting }
   end
+
+  # POST /api/graphs
+  def create
+    graph = current_user.graphs.new(graph_params)
+    if graph.save
+      render json: { graph: graph }, status: :ok
+    else
+      render json: { error: '保存に失敗しました' }, status: :unprocessable_entity
+    end
+  end
+
+
+  private
+  def graph_params
+    params.require(:graph).permit(:title, :note)
+  end
 end

--- a/app/controllers/api/graphs_controller.rb
+++ b/app/controllers/api/graphs_controller.rb
@@ -1,2 +1,5 @@
 class Api::GraphsController < Api::BaseController
+  def index
+    render json: { message: 'Hello, World!' }
+  end
 end

--- a/app/controllers/api/graphs_controller.rb
+++ b/app/controllers/api/graphs_controller.rb
@@ -1,5 +1,14 @@
 class Api::GraphsController < Api::BaseController
+  # GET /api/graphs
+  # テスト表示用
   def index
-    render json: { message: 'Hello, World!' }
+    graphs = Graph.all
+    render json: { message: 'Hello, World!', graphs: graphs }
+  end
+
+  # GET /api/graphs/:id
+  def show
+    graph = Graph.find(params[:id])
+    render json: { graph: graph, graph_setting: graph.graph_setting }
   end
 end

--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -15,7 +15,7 @@ const style = {
   p: 4,
 };
 
-export default function MyGraphModal() {
+export default function MyGraphModal({ graphSetting }) {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
@@ -37,8 +37,9 @@ export default function MyGraphModal() {
         data.note,
       )
       if (response.ok) {
-        // const responseData = await response.json();
+        const responseData = await response.json();
         console.log('送信リクエスト完了！')
+        console.log('responseData : ', responseData);
         reset();       //フォームのリセット
         // closeModal();  //モーダルを閉じる
       } else {
@@ -61,7 +62,7 @@ export default function MyGraphModal() {
         graph: {
           title,
           note,
-          // graph_settingをドッキングするならここに追加する
+          graph_setting: graphSetting,
         },
       }),
     })

--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -38,6 +38,7 @@ export default function MyGraphModal() {
       )
       if (response.ok) {
         // const responseData = await response.json();
+        console.log('送信リクエスト完了！')
         reset();       //フォームのリセット
         // closeModal();  //モーダルを閉じる
       } else {
@@ -57,11 +58,10 @@ export default function MyGraphModal() {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        item: {
+        graph: {
           title,
           note,
-          assignee,
-          category_id: 2,  //⭐Propsでこのコンポーネントに渡すようにする
+          // graph_settingをドッキングするならここに追加する
         },
       }),
     })
@@ -87,7 +87,7 @@ export default function MyGraphModal() {
               
               {/* Title */}
               <label htmlFor="title" className="mb-2 text-lg">
-                Title
+                タイトル
               </label>
               <input
                 {...register('title', { required: 'Titleを入力して下さい。' })}
@@ -96,7 +96,7 @@ export default function MyGraphModal() {
 
               {/* Note */}
               <label htmlFor="note" className="mb-2 text-lg">
-                Content
+                メモ
               </label>
               <textarea
                 {...register('note')}

--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useForm } from "react-hook-form";
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
 
@@ -13,27 +14,101 @@ const style = {
   boxShadow: 24,
   p: 4,
 };
+
 export default function MyGraphModal() {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
+  const {       //フォームの設定。register, handleSubmit, resetはuseFormから取得できる
+    register,
+    handleSubmit,
+    reset,
+    // formState: { errors },
+  } = useForm();
+
+  const [serverError, setServerError] = useState(''); //サーバーエラーのステート
+
+  //⭐ フォームの送信処理
+  const onSubmit = async (data) => {
+    try {
+      const response = await createGraph(  //バックへPOSTリクエスト, 後ろで定義
+        data.title,
+        data.note,
+      )
+      if (response.ok) {
+        // const responseData = await response.json();
+        reset();       //フォームのリセット
+        // closeModal();  //モーダルを閉じる
+      } else {
+        // setServerError('サーバーエラーが発生しました。');
+        console.log('サーバーエラーが発生しました。');
+      }
+    } catch (error) {
+      setServerError('リクエスト中にエラーが発生しました。');
+    }
+  }
+
+  // onSubmitで呼ばれるバックへの送信処理
+  const createGraph = async (title, note) => {
+    const response = await fetch('/api/graphs', {  //エンドポイントは/api/graphsのPOST → api/graphsコントローラーのcreateアクションを参照
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        item: {
+          title,
+          note,
+          assignee,
+          category_id: 2,  //⭐Propsでこのコンポーネントに渡すようにする
+        },
+      }),
+    })
+    return response;
+  }
+
   return (
     <div className='my-5'>
-        <button className="btn btn-primary" onClick={handleOpen}>MyGraph</button>
-        <Modal
-          open={open}
-          onClose={handleClose}
-          aria-labelledby="modal-modal-title"
-          aria-describedby="modal-modal-description"
-        >
-          <Box className="" sx={style}>
-            <div className="container">
+      <button className="btn btn-primary" onClick={handleOpen}>MyGraph</button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box className="" sx={style}>
+          <div className="container">
+            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
               <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイグラフ保存</h2>
+              {/* エラーメッセージ表示部分 */}
+              {/* <ErrorMessage message={serverError} />
+              <ErrorMessage message={errors.title?.message || ''} /> */}
+              
+              {/* Title */}
+              <label htmlFor="title" className="mb-2 text-lg">
+                Title
+              </label>
+              <input
+                {...register('title', { required: 'Titleを入力して下さい。' })}
+                className="input input-bordered mb-5"
+              />
 
-            </div>
-          </Box>
-        </Modal>
+              {/* Note */}
+              <label htmlFor="note" className="mb-2 text-lg">
+                Content
+              </label>
+              <textarea
+                {...register('note')}
+                className="textarea textarea-bordered mb-5"
+              />
+              <button type="submit" className="btn mt-2">
+                マイグラフ保存
+              </button>
+            </form>
+          </div>
+        </Box>
+      </Modal>
     </div>
   )
 }

--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import Box from '@mui/material/Box';
+import Modal from '@mui/material/Modal';
+
+const style = {
+  position: 'absolute',
+  top: '30%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+};
+export default function MyGraphModal() {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <div className='my-5'>
+        <button className="btn btn-primary" onClick={handleOpen}>MyGraph</button>
+        <Modal
+          open={open}
+          onClose={handleClose}
+          aria-labelledby="modal-modal-title"
+          aria-describedby="modal-modal-description"
+        >
+          <Box className="" sx={style}>
+            <div className="container">
+              <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイグラフ保存</h2>
+
+            </div>
+          </Box>
+        </Modal>
+    </div>
+  )
+}

--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -70,7 +70,7 @@ export default function MyGraphModal() {
 
   return (
     <div className='my-5'>
-      <button className="btn btn-primary" onClick={handleOpen}>MyGraph</button>
+      <button className="btn btn-primary" onClick={handleOpen}>マイグラフ保存</button>
       <Modal
         open={open}
         onClose={handleClose}

--- a/app/javascript/react/canvas/components/download_image/download_image_button.jsx
+++ b/app/javascript/react/canvas/components/download_image/download_image_button.jsx
@@ -29,7 +29,7 @@ export default function DownloadImageButton() {
   return (
     <div className='my-5'>
       <div>
-        <button className="btn btn-primary" onClick={handleOpen}>Open modal</button>
+        <button className="btn btn-primary" onClick={handleOpen}>画像DL</button>
         <Modal
           open={open}
           onClose={handleClose}

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -63,7 +63,7 @@ export default function MainWithRightDrawer() {
       <Main open={open}>
         <button onClick={handleDrawerOpen} className='btn btn-info'>Right</button>
         
-        <MyGraphModal />
+        <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
 
         <DownloadImageButton />        
 
@@ -102,7 +102,7 @@ export default function MainWithRightDrawer() {
         </div>
 
         {/* ここにグラフ設定値入力コンポーネント */}
-        {/* <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/> */}
+        <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/>
         {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
 
       </Drawer>

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -96,7 +96,7 @@ export default function MainWithRightDrawer() {
         </div>
 
         {/* ここにグラフ設定値入力コンポーネント */}
-        {/* <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/> */}
+        <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/>
         {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
 
       </Drawer>

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -7,6 +7,8 @@ import Drawer from '@mui/material/Drawer';
 import Graph from './graph/graph';
 import GraphSettings from './graph_settings/graph_settings';
 import DownloadImageButton from './download_image/download_image_button';
+import MyGraphModal from './create_mygraph/mygraph_modal';
+
 
 const drawerWidth = 300;
 
@@ -60,7 +62,11 @@ export default function MainWithRightDrawer() {
     <Box sx={{ display: 'flex' }} className='bg-red-200'>
       <Main open={open}>
         <button onClick={handleDrawerOpen} className='btn btn-info'>Right</button>
-        <DownloadImageButton />
+        
+        <MyGraphModal />
+
+        <DownloadImageButton />        
+
         {/* ここにグラフ */}
         <div className='flex justify-center items-center bg-blue-200'>
           <Graph lineDotSize={lineDotSize}/>

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -96,7 +96,7 @@ export default function MainWithRightDrawer() {
         </div>
 
         {/* ここにグラフ設定値入力コンポーネント */}
-        <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/>
+        {/* <GraphSettings lineDotSize={lineDotSize} handleValueChange={handleValueChange}/> */}
         {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
 
       </Drawer>

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
 import { makeStyles } from "@material-ui/core/styles";
 import Box from '@mui/material/Box';
@@ -8,7 +8,7 @@ import Graph from './graph/graph';
 import GraphSettings from './graph_settings/graph_settings';
 import DownloadImageButton from './download_image/download_image_button';
 import MyGraphModal from './create_mygraph/mygraph_modal';
-
+import { useGraph } from '../hooks/useGraph';
 
 const drawerWidth = 300;
 
@@ -38,18 +38,23 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
 );
 
 export default function MainWithRightDrawer() {
-  const [open, setOpen] = useState(true);
+  const { graph, setGraph, loading } = useGraph();
 
+  const [open, setOpen] = useState(true);
   const handleDrawerOpen = () => {
     setOpen(true);
   };
-
   const handleDrawerClose = () => {
     setOpen(false);
   };
 
   // GraphSettingsのstateとハンドラを宣言
-  const [lineDotSize, setLineDotSize] = useState(4);
+  const [lineDotSize, setLineDotSize] = useState(4); //useGraphでデータを取得するまでの初期値
+  useEffect(() => {
+    if (graph.graph_setting) {
+      setLineDotSize(graph.graph_setting.settings.dotSize);
+    }
+  }, [graph]);
 
   const handleValueChange = (value) => {
     if (value !== '') {
@@ -57,6 +62,11 @@ export default function MainWithRightDrawer() {
     }
   }
 
+  console.log('Graph Data from Backend!', graph);
+  
+  if (loading) {
+    return <div>loading...</div>
+  }
 
   return (
     <Box sx={{ display: 'flex' }} className='bg-red-200'>
@@ -65,7 +75,10 @@ export default function MainWithRightDrawer() {
         
         <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
 
-        <DownloadImageButton />        
+        <DownloadImageButton />      
+
+        <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
+        <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div>
 
         {/* ここにグラフ */}
         <div className='flex justify-center items-center bg-blue-200'>

--- a/app/javascript/react/canvas/hooks/useGraph.js
+++ b/app/javascript/react/canvas/hooks/useGraph.js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 
 export const useGraph = () => {
-  console.log('Running useGraph!')
   const [graph, setGraph] = useState([]);
   const [loading, setLoading] = useState(true);
 

--- a/app/javascript/react/canvas/hooks/useGraph.js
+++ b/app/javascript/react/canvas/hooks/useGraph.js
@@ -7,7 +7,7 @@ export const useGraph = () => {
   useEffect(() => {
     async function fetchGraph() {
       try {
-        const response = await fetch('/api/graphs/1');
+        const response = await fetch('/api/graphs/6');
         if (response.ok) {
           const graph = await response.json();
           setGraph(graph);

--- a/app/javascript/react/canvas/hooks/useGraph.js
+++ b/app/javascript/react/canvas/hooks/useGraph.js
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+export const useGraph = () => {
+  const [graph, setGraph] = useState(null);
+
+  useEffect(() => {
+    async function fetchGraph() {
+      try {
+        const response = await fetch('ここにエンドポイント');
+        if (response.ok) {
+          const graph = await response.json();
+          setGraph(graph);
+        } else {
+          console.log('server error!');
+        }
+      } catch (error) {
+          console.log('failed to fetch', error);
+      }
+    }
+
+    fetchGraph();
+  }, [])
+
+  return { graph, setGraph }
+}

--- a/app/javascript/react/canvas/hooks/useGraph.js
+++ b/app/javascript/react/canvas/hooks/useGraph.js
@@ -1,15 +1,18 @@
 import { useState, useEffect } from 'react';
 
 export const useGraph = () => {
-  const [graph, setGraph] = useState(null);
+  console.log('Running useGraph!')
+  const [graph, setGraph] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function fetchGraph() {
       try {
-        const response = await fetch('ここにエンドポイント');
+        const response = await fetch('/api/graphs/1');
         if (response.ok) {
           const graph = await response.json();
           setGraph(graph);
+          setLoading(false);
         } else {
           console.log('server error!');
         }
@@ -21,5 +24,5 @@ export const useGraph = () => {
     fetchGraph();
   }, [])
 
-  return { graph, setGraph }
+  return { graph, setGraph, loading }
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -5,7 +5,6 @@ import BottomDrawer from './components/bottom_drawer';
 import { useGraph } from './hooks/useGraph';
 import MyGraphModal from './components/create_mygraph/mygraph_modal';
 
-
 export default function CanvasApp() {
   const { graph, setGraph, loading } = useGraph();
   console.log('Graph Data from Backend!', graph);

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -2,18 +2,21 @@ import React from 'react';
 import Graph from './components/graph/graph';
 import MainWithRightDrawer from './components/main_with_right_drawer';
 import BottomDrawer from './components/bottom_drawer';
+import { useGraph } from './hooks/useGraph';
+
 
 export default function CanvasApp() {
+  const { graph, setGraph, loading } = useGraph();
+  console.log('Graph Data from Backend!', graph);
+  
+  if (loading) {
+    return <div>loading...</div>
+  }
+
   return (
     <div className=''>
-      {/* <div className='flex flex-1 justify-center items-center bg-blue-200'>
-        <div className='mt-10'>
-          <Graph />
-        </div>
-      </div>
-      <div className='w-full flex-shrink-0 max-w-xs bg-green-200 '>
-        テスト
-      </div> */}
+      <div className='text-xl'> {graph.graph.title} </div>
+      <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div>
       <MainWithRightDrawer />
       <BottomDrawer />      
     </div>

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -2,20 +2,11 @@ import React from 'react';
 import Graph from './components/graph/graph';
 import MainWithRightDrawer from './components/main_with_right_drawer';
 import BottomDrawer from './components/bottom_drawer';
-import { useGraph } from './hooks/useGraph';
 
 export default function CanvasApp() {
-  const { graph, setGraph, loading } = useGraph();
-  console.log('Graph Data from Backend!', graph);
-  
-  if (loading) {
-    return <div>loading...</div>
-  }
 
   return (
     <div className=''>
-      <div className='text-xl'> {graph.graph.title} </div>
-      <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div>
       <MainWithRightDrawer />
       <BottomDrawer />      
     </div>

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -3,6 +3,7 @@ import Graph from './components/graph/graph';
 import MainWithRightDrawer from './components/main_with_right_drawer';
 import BottomDrawer from './components/bottom_drawer';
 import { useGraph } from './hooks/useGraph';
+import MyGraphModal from './components/create_mygraph/mygraph_modal';
 
 
 export default function CanvasApp() {
@@ -17,6 +18,7 @@ export default function CanvasApp() {
     <div className=''>
       <div className='text-xl'> {graph.graph.title} </div>
       <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div>
+      <MyGraphModal />
       <MainWithRightDrawer />
       <BottomDrawer />      
     </div>

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -3,7 +3,6 @@ import Graph from './components/graph/graph';
 import MainWithRightDrawer from './components/main_with_right_drawer';
 import BottomDrawer from './components/bottom_drawer';
 import { useGraph } from './hooks/useGraph';
-import MyGraphModal from './components/create_mygraph/mygraph_modal';
 
 export default function CanvasApp() {
   const { graph, setGraph, loading } = useGraph();
@@ -17,7 +16,6 @@ export default function CanvasApp() {
     <div className=''>
       <div className='text-xl'> {graph.graph.title} </div>
       <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div>
-      <MyGraphModal />
       <MainWithRightDrawer />
       <BottomDrawer />      
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
   
   resources :users, only: %i[new create destroy]
   
+  namespace :api do
+    resources :graphs, only: %i[index show create]
+  end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postcss": "^8.4.38",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.51.4",
     "recharts": "^2.12.7",
     "tailwindcss": "^3.4.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1723,6 +1723,11 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-hook-form@^7.51.4:
+  version "7.51.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.51.4.tgz#c3a47aeb22b699c45de9fc12b58763606cb52f0c"
+  integrity sha512-V14i8SEkh+V1gs6YtD0hdHYnoL4tp/HX/A45wWQN15CYr9bFRmmRdYStSO5L65lCCZRF+kYiSKhm9alqbcdiVA==
+
 react-is@^16.10.2, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/112

- フロント→バックへデータ送信
- バック→フロントにデータ反映
この両方ができることを，テストコードで確認しました。

## フロント→バックへデータ送信
- main_with_right_drawerに，マイグラフ保存用の仮モーダルを設置しました（mygraph_modal.jsx）
- react-form-hookをインストールしました
- Graphのタイトルとメモ，さらにグラフ設定値をオブジェクト形式で，指定したエンドポイントに送信する処理をmygraph_modal内に記述しました。
- api通信を担うコントローラー群として，名前空間 api を作成し，そのベースとなる api/baseコントローラーと，baseを継承するapi/graphsコントローラーを作成しました。
- api/graphsコントローラーのcreateアクションを，フロント側からのデータ送信のエンドポイントとしています（api/graphs　へのPOSTリクエスト）
- トランザクションを利用し，graphとgraph_settingのsaveが両方とも成功したとき以外は，ロールバックするようにしました。
- テストデータを送信し，画面上で設定したdotSize値が，適切にデータ保存されていることを確認しました（テンプレートは未実装）


## バック→フロントへデータ反映
- マイグラフ一覧からグラフ編集メインページ（canvas）へ遷移させた場合等を想定し，バックからfetchしたデータが画面上に反映されるかを確かめました。
- api/graphsコントローラーのshowアクション（api/graphs/:id）をfetchのエンドポイントとし，リクエストされたidのGraphのデータを，jsonで送り返すようにしました。
- useEffectを用いたuseGraph.jsを作成し，非同期で指定したエンドポイントに対してfetchをかけるようにしました。エンドポイントは，テスト段階のため固定しています
- データが取得できた時に別のuseEffectを発動させ，dotSizeが適切に更新され画面上のグラフが変化することを確認しました。


![image](https://github.com/g-sawada/u-on-zu/assets/118000212/11b4f9df-baab-4247-b9f1-b383d5261f59)
![image](https://github.com/g-sawada/u-on-zu/assets/118000212/d9fafde2-88e0-423f-91ce-e933fe0b724f)


close #112 