### PR TITLE
メイン画面上部にドロワー・モーダルの開閉制御バーを集約する

### DIFF
--- a/app/javascript/react/canvas/components/bottom_drawer.jsx
+++ b/app/javascript/react/canvas/components/bottom_drawer.jsx
@@ -2,15 +2,7 @@ import React, { useState } from 'react';
 import Box from '@mui/material/Box';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 
-export default function BottomDrawer() {
-  const [state, setState] = useState(false);
-
-  const toggleDrawer = (open) => (event) => {
-    if (event && event.type === 'keydown' && (event.key === 'Tab' || event.key === 'Shift')) { 
-      return; 
-    }
-    setState(open);
-  };
+export default function BottomDrawer({open, handleClose}) {
 
   const list = () => (
     <>
@@ -24,23 +16,12 @@ export default function BottomDrawer() {
   );
 
   return (
-    <React.Fragment>
-      <div className='my-5'>
-        <button 
-          className='btn btn-primary btn-sm' 
-          onClick={toggleDrawer(true)}
-        >
-          Bottom
-        </button>
-      </div>
-      <SwipeableDrawer
-        anchor='bottom'
-        open={state}
-        onClose={toggleDrawer(false)}
-        onOpen={toggleDrawer(true)}
-      >
-        {list()}
-      </SwipeableDrawer>
-    </React.Fragment>
+    <SwipeableDrawer
+      anchor='bottom'
+      open={open}
+      onClose={handleClose}
+    >
+      {list()}
+    </SwipeableDrawer>
   );
 }

--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -5,7 +5,7 @@ import Modal from '@mui/material/Modal';
 
 const style = {
   position: 'absolute',
-  top: '30%',
+  top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
   width: 400,
@@ -15,10 +15,7 @@ const style = {
   p: 4,
 };
 
-export default function MyGraphModal({ graphSetting }) {
-  const [open, setOpen] = useState(false);
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
+export default function MyGraphModal({ graphSetting, open, handleClose }) {
 
   const {       //フォームの設定。register, handleSubmit, resetはuseFormから取得できる
     register,
@@ -70,46 +67,43 @@ export default function MyGraphModal({ graphSetting }) {
   }
 
   return (
-    <div className='my-5'>
-      <button className="btn btn-primary" onClick={handleOpen}>マイグラフ保存</button>
-      <Modal
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="modal-modal-title"
-        aria-describedby="modal-modal-description"
-      >
-        <Box className="" sx={style}>
-          <div className="container">
-            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
-              <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイグラフ保存</h2>
-              {/* エラーメッセージ表示部分 */}
-              {/* <ErrorMessage message={serverError} />
-              <ErrorMessage message={errors.title?.message || ''} /> */}
-              
-              {/* Title */}
-              <label htmlFor="title" className="mb-2 text-lg">
-                タイトル
-              </label>
-              <input
-                {...register('title', { required: 'Titleを入力して下さい。' })}
-                className="input input-bordered mb-5"
-              />
+    <Modal
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box className="" sx={style}>
+        <div className="container">
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
+            <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイグラフ保存</h2>
+            {/* エラーメッセージ表示部分 */}
+            {/* <ErrorMessage message={serverError} />
+            <ErrorMessage message={errors.title?.message || ''} /> */}
+            
+            {/* Title */}
+            <label htmlFor="title" className="mb-2 text-lg">
+              タイトル
+            </label>
+            <input
+              {...register('title', { required: 'Titleを入力して下さい。' })}
+              className="input input-bordered mb-5"
+            />
 
-              {/* Note */}
-              <label htmlFor="note" className="mb-2 text-lg">
-                メモ
-              </label>
-              <textarea
-                {...register('note')}
-                className="textarea textarea-bordered mb-5"
-              />
-              <button type="submit" className="btn mt-2">
-                マイグラフ保存
-              </button>
-            </form>
-          </div>
-        </Box>
-      </Modal>
-    </div>
+            {/* Note */}
+            <label htmlFor="note" className="mb-2 text-lg">
+              メモ
+            </label>
+            <textarea
+              {...register('note')}
+              className="textarea textarea-bordered mb-5"
+            />
+            <button type="submit" className="btn mt-2">
+              マイグラフ保存
+            </button>
+          </form>
+        </div>
+      </Box>
+    </Modal>
   )
 }

--- a/app/javascript/react/canvas/components/download_image/download_image_button.jsx
+++ b/app/javascript/react/canvas/components/download_image/download_image_button.jsx
@@ -8,7 +8,7 @@ import { downloadImage } from './downloadImage';
 
 const style = {
   position: 'absolute',
-  top: '30%',
+  top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
   width: 400,
@@ -21,10 +21,9 @@ const style = {
 export default function DownloadImageButton({
   layoutHeight,
   layoutWidth,
-  graphTitle }) {
-  const [open, setOpen] = useState(false);
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
+  graphTitle,
+  open, handleClose
+  }) {
 
   //出力ファイル設定を別で管理
   const [outputHeight, setOutputHeight] = useState(Number(layoutHeight));
@@ -38,10 +37,8 @@ export default function DownloadImageButton({
     setOutputFileName(graphTitle);
   },[layoutHeight, layoutWidth, graphTitle])
 
-
   return (
     <>
-        <button className="btn btn-primary" onClick={handleOpen}>画像DL</button>
         <Modal
           open={open}
           onClose={handleClose}

--- a/app/javascript/react/canvas/components/download_image/download_image_button.jsx
+++ b/app/javascript/react/canvas/components/download_image/download_image_button.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
+import Button from '@mui/material/Button';
 
 import { downloadImage } from './downloadImage';
 
@@ -39,8 +40,7 @@ export default function DownloadImageButton({
 
 
   return (
-    <div className='my-5'>
-      <div>
+    <>
         <button className="btn btn-primary" onClick={handleOpen}>画像DL</button>
         <Modal
           open={open}
@@ -92,10 +92,6 @@ export default function DownloadImageButton({
             </div>
           </Box>
         </Modal>
-      </div>
-
-      <div>ここにImage</div>
-      <img alt="" id="output" />
-    </div>
+    </>
   )
 }

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -3,7 +3,10 @@ import { styled } from '@mui/material/styles';
 import { makeStyles } from "@material-ui/core/styles";
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
 
+import BottomDrawer from './bottom_drawer';
 import Graph from './graph/graph';
 import GraphSettings from './graph_settings/graph_settings';
 import DownloadImageButton from './download_image/download_image_button';
@@ -117,60 +120,79 @@ export default function MainWithRightDrawer() {
   }
 
   return (
-    <Box sx={{ display: 'flex' }} className='bg-red-200'>
-      <Main open={open}>
-        <button onClick={handleDrawerOpen} className='btn btn-info'>Right</button>
-        
-        <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
+    <>
+      <Box sx={{ display: 'flex' }} className='bg-red-200'>
+        <Main open={open}>
+          
+          <ButtonGroup variant="contained" aria-label="Basic button group">
+            <Button>
+              <DownloadImageButton 
+              layoutHeight={settingValues.layoutHeight}  
+              layoutWidth={settingValues.layoutWidth}
+              graphTitle={settingValues.title}
+              />
+            </Button>
+            <Button>
+              <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
+            </Button>
+            <Button>Three</Button>
+          </ButtonGroup>
 
-        <DownloadImageButton 
-          layoutHeight={settingValues.layoutHeight}  
-          layoutWidth={settingValues.layoutWidth}
-          graphTitle={settingValues.title}
-          />   
+          <div className='join'>
+            <div>あああ</div>
+            <button class="btn join-item">Button</button>
+            <button class="btn join-item">Button</button>
+            <button onClick={handleDrawerOpen} className='btn btn-info join-item'>Right</button>
+          </div>
 
-        {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
-        <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
 
-        {/* ここにグラフ */}
-        <div className='flex justify-center items-center bg-blue-200'>
-          <Graph sv={settingValues}/>
-        </div>
+          
 
-      </Main>
-      <Drawer
-        sx={{
-          position: 'relative',
-          marginLeft: "auto",
-          width: drawerWidth,
-          "& .MuiBackdrop-root": {
-            display: "none"
-          },
-          "& .MuiDrawer-paper": {
+
+          {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
+          <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
+
+          {/* ここにグラフ */}
+          <div className='flex justify-center items-center bg-blue-200'>
+            <Graph sv={settingValues}/>
+          </div>
+
+        </Main>
+        <Drawer
+          sx={{
+            position: 'relative',
+            marginLeft: "auto",
             width: drawerWidth,
-            height: "100%",
-            position: "absolute",
-            backgroundColor: "limegreen",
-            display: "flex",
-            padding: "20px",
-            alignItems: "center",
-          }
-        }}
-        // className={[classes.drawer, 'text-3xl']}
-        variant="persistent"
-        anchor="right"
-        open={open}
-      > 
-        {/* ここからDrawerの中身 */}
-        <div>
-          <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
-        </div>
+            "& .MuiBackdrop-root": {
+              display: "none"
+            },
+            "& .MuiDrawer-paper": {
+              width: drawerWidth,
+              height: "100%",
+              position: "absolute",
+              backgroundColor: "limegreen",
+              display: "flex",
+              padding: "20px",
+              alignItems: "center",
+            }
+          }}
+          // className={[classes.drawer, 'text-3xl']}
+          variant="persistent"
+          anchor="right"
+          open={open}
+        > 
+          {/* ここからDrawerの中身 */}
+          <div>
+            <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
+          </div>
 
-        {/* ここにグラフ設定値入力コンポーネント */}
-        <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
-        {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
+          {/* ここにグラフ設定値入力コンポーネント */}
+          <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
+          {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
 
-      </Drawer>
-    </Box>
+        </Drawer>
+      </Box>
+      <BottomDrawer />      
+    </>
   );
 }

--- a/app/javascript/react/canvas/components/main_with_right_drawer.jsx
+++ b/app/javascript/react/canvas/components/main_with_right_drawer.jsx
@@ -1,198 +1,198 @@
-import React, { useState, useEffect } from 'react';
-import { styled } from '@mui/material/styles';
-import { makeStyles } from "@material-ui/core/styles";
-import Box from '@mui/material/Box';
-import Drawer from '@mui/material/Drawer';
-import Button from '@mui/material/Button';
-import ButtonGroup from '@mui/material/ButtonGroup';
+// import React, { useState, useEffect } from 'react';
+// import { styled } from '@mui/material/styles';
+// import { makeStyles } from "@material-ui/core/styles";
+// import Box from '@mui/material/Box';
+// import Drawer from '@mui/material/Drawer';
+// import Button from '@mui/material/Button';
+// import ButtonGroup from '@mui/material/ButtonGroup';
 
-import BottomDrawer from './bottom_drawer';
-import Graph from './graph/graph';
-import GraphSettings from './graph_settings/graph_settings';
-import DownloadImageButton from './download_image/download_image_button';
-import MyGraphModal from './create_mygraph/mygraph_modal';
-import { useGraph } from '../hooks/useGraph';
+// import BottomDrawer from './bottom_drawer';
+// import Graph from './graph/graph';
+// import GraphSettings from './graph_settings/graph_settings';
+// import DownloadImageButton from './download_image/download_image_button';
+// import MyGraphModal from './create_mygraph/mygraph_modal';
+// import { useGraph } from '../hooks/useGraph';
 
-const drawerWidth = 300;
+// const drawerWidth = 300;
 
-const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
-  ({ theme, open }) => ({
-    flexGrow: 1,
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    marginRight: -drawerWidth,
-    ...(open && {
-      transition: theme.transitions.create('margin', {
-        easing: theme.transitions.easing.easeOut,
-        duration: theme.transitions.duration.enteringScreen,
-      }),
-      marginRight: 0,
-    }),
-    /**
-     * This is necessary to enable the selection of content. In the DOM, the stacking order is determined
-     * by the order of appearance. Following this rule, elements appearing later in the markup will overlay
-     * those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures
-     * proper interaction with the underlying content.
-     */
-    position: 'relative',
-  }),
-);
+// const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
+//   ({ theme, open }) => ({
+//     flexGrow: 1,
+//     transition: theme.transitions.create('margin', {
+//       easing: theme.transitions.easing.sharp,
+//       duration: theme.transitions.duration.leavingScreen,
+//     }),
+//     marginRight: -drawerWidth,
+//     ...(open && {
+//       transition: theme.transitions.create('margin', {
+//         easing: theme.transitions.easing.easeOut,
+//         duration: theme.transitions.duration.enteringScreen,
+//       }),
+//       marginRight: 0,
+//     }),
+//     /**
+//      * This is necessary to enable the selection of content. In the DOM, the stacking order is determined
+//      * by the order of appearance. Following this rule, elements appearing later in the markup will overlay
+//      * those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures
+//      * proper interaction with the underlying content.
+//      */
+//     position: 'relative',
+//   }),
+// );
 
-export default function MainWithRightDrawer() {
-  const { graph, setGraph, loading } = useGraph();
+// export default function MainWithRightDrawer() {
+//   const { graph, setGraph, loading } = useGraph();
 
-  const [open, setOpen] = useState(true);
-  const handleDrawerOpen = () => {
-    setOpen(true);
-  };
-  const handleDrawerClose = () => {
-    setOpen(false);
-  };
+//   const [open, setOpen] = useState(true);
+//   const handleDrawerOpen = () => {
+//     setOpen(true);
+//   };
+//   const handleDrawerClose = () => {
+//     setOpen(false);
+//   };
 
-  // GraphSettingsのstateとハンドラを宣言
-  const [lineDotSize, setLineDotSize] = useState(4); //useGraphでデータを取得するまでの初期値
+//   // GraphSettingsのstateとハンドラを宣言
+//   const [lineDotSize, setLineDotSize] = useState(4); //useGraphでデータを取得するまでの初期値
 
-  const [settingValues, setSettingValues] = useState({
-    lineColor: '#FF0000',                  //線の色
-    lineWidth: 1.5,                          //線の太さ
-    dotOutlineColor: '#FF0000',            //ドットの外枠の色
-    dotFillColor: '#FFFFFF',               //ドットの塗りつぶしの色
-    dotSize: 4,                            //ドットのサイズ
-    dotOutlineWidth: 1,                    //ドットの外枠の太さ
-    tempMax: 40,                           //気温の目盛り最大値
-    tempMin: -30,                          //気温の目盛り最小値
-    scaleCount: 8,                         //目盛りの数（棒グラフと共通）
-    tempYAxisFontSize: 16,                 //Y軸目盛りのフォントサイズ
-    tempYAxisFontColor: '#000000',         //Y軸目盛りのフォントカラー
-    tempYAxisLineWidth: 1,                 //Y軸の線の太さ
-    tempYAxisLineColor: '#000000',         //Y軸の線のカラー
+//   const [settingValues, setSettingValues] = useState({
+//     lineColor: '#FF0000',                  //線の色
+//     lineWidth: 1.5,                          //線の太さ
+//     dotOutlineColor: '#FF0000',            //ドットの外枠の色
+//     dotFillColor: '#FFFFFF',               //ドットの塗りつぶしの色
+//     dotSize: 4,                            //ドットのサイズ
+//     dotOutlineWidth: 1,                    //ドットの外枠の太さ
+//     tempMax: 40,                           //気温の目盛り最大値
+//     tempMin: -30,                          //気温の目盛り最小値
+//     scaleCount: 8,                         //目盛りの数（棒グラフと共通）
+//     tempYAxisFontSize: 16,                 //Y軸目盛りのフォントサイズ
+//     tempYAxisFontColor: '#000000',         //Y軸目盛りのフォントカラー
+//     tempYAxisLineWidth: 1,                 //Y軸の線の太さ
+//     tempYAxisLineColor: '#000000',         //Y軸の線のカラー
 
-    barFillColor: '#00FFFF',               //棒グラフの塗りつぶしの色
-    barOutlineColor: '#000000',            //棒グラフの外枠の色
-    barBinWidth: 30,                       //棒グラフの幅
-    barOutlineWidth: 1,                    //棒グラフの外枠の太さ
-    rainMax: 700,                          //降水量の目盛り最大値
-    rainYAxisFontSize: 16,                 //Y軸目盛りのフォントサイズ
-    rainYAxisFontColor: '#000000',         //Y軸目盛りのフォントカラー
-    rainYAxisLineWidth: 1,                 //Y軸の線の太さ
-    rainYAxisLineColor: '#000000',         //Y軸の線のカラー
+//     barFillColor: '#00FFFF',               //棒グラフの塗りつぶしの色
+//     barOutlineColor: '#000000',            //棒グラフの外枠の色
+//     barBinWidth: 30,                       //棒グラフの幅
+//     barOutlineWidth: 1,                    //棒グラフの外枠の太さ
+//     rainMax: 700,                          //降水量の目盛り最大値
+//     rainYAxisFontSize: 16,                 //Y軸目盛りのフォントサイズ
+//     rainYAxisFontColor: '#000000',         //Y軸目盛りのフォントカラー
+//     rainYAxisLineWidth: 1,                 //Y軸の線の太さ
+//     rainYAxisLineColor: '#000000',         //Y軸の線のカラー
 
-    xAxisFontSize: 12,                     //X軸目盛りのフォントサイズ
-    xAxisFontColor: '#000000',             //X軸目盛りのフォントカラー
-    xAxisLineWidth: 1,                     //X軸の線の太さ
-    xAxisLineColor: '#000000',             //X軸の線のカラー
+//     xAxisFontSize: 12,                     //X軸目盛りのフォントサイズ
+//     xAxisFontColor: '#000000',             //X軸目盛りのフォントカラー
+//     xAxisLineWidth: 1,                     //X軸の線の太さ
+//     xAxisLineColor: '#000000',             //X軸の線のカラー
 
-    title: '東京',                          //グラフタイトル
-    titleFontSize: 24,                     //グラフタイトルのフォントサイズ
-    titleFontColor: '#000000',             //グラフタイトルのフォントカラー
+//     title: '東京',                          //グラフタイトル
+//     titleFontSize: 24,                     //グラフタイトルのフォントサイズ
+//     titleFontColor: '#000000',             //グラフタイトルのフォントカラー
 
-    layoutHeight: 500,                     //グラフの高さ
-    layoutWidth: 500,                      //グラフの幅
-    marginTop: 50,                         //グラフの上マージン
-    marginBottom: 60,                      //グラフの下マージン
-    marginLeft: 20,                        //グラフの左マージン
-    marginRight: 20,                       //グラフの右マージン
-    backgroundColor: '#FFFFFF',            //グラフの背景色
-    fontfamily: 'sans-serif',              //フォントファミリー
-  });
+//     layoutHeight: 500,                     //グラフの高さ
+//     layoutWidth: 500,                      //グラフの幅
+//     marginTop: 50,                         //グラフの上マージン
+//     marginBottom: 60,                      //グラフの下マージン
+//     marginLeft: 20,                        //グラフの左マージン
+//     marginRight: 20,                       //グラフの右マージン
+//     backgroundColor: '#FFFFFF',            //グラフの背景色
+//     fontfamily: 'sans-serif',              //フォントファミリー
+//   });
 
 
-  //graphデータが取得できたら，state値を更新
-  useEffect(() => {
-    if (graph.graph_setting) {
-      setLineDotSize(graph.graph_setting.settings.dotSize);
-    }
-  }, [graph]);
+//   //graphデータが取得できたら，state値を更新
+//   useEffect(() => {
+//     if (graph.graph_setting) {
+//       setLineDotSize(graph.graph_setting.settings.dotSize);
+//     }
+//   }, [graph]);
 
-  //GraphSettingsコンポーネントに渡すハンドラ
-  const handleValueChange = (name, value) => {
-    setSettingValues({...settingValues, [name]: value});
-  }
+//   //GraphSettingsコンポーネントに渡すハンドラ
+//   const handleValueChange = (name, value) => {
+//     setSettingValues({...settingValues, [name]: value});
+//   }
 
-  // console.log('Graph Data from Backend!', graph);
-  // console.log('lineWidth :', settingValues.lineWidth);
-  console.log('fontFamily :', settingValues.fontfamily);
+//   // console.log('Graph Data from Backend!', graph);
+//   // console.log('lineWidth :', settingValues.lineWidth);
+//   console.log('fontFamily :', settingValues.fontfamily);
   
-  if (loading) {
-    return <div>loading...</div>
-  }
+//   if (loading) {
+//     return <div>loading...</div>
+//   }
 
-  return (
-    <>
-      <Box sx={{ display: 'flex' }} className='bg-red-200'>
-        <Main open={open}>
+//   return (
+//     <>
+//       <Box sx={{ display: 'flex' }} className='bg-red-200'>
+//         <Main open={open}>
           
-          <ButtonGroup variant="contained" aria-label="Basic button group">
-            <Button>
-              <DownloadImageButton 
-              layoutHeight={settingValues.layoutHeight}  
-              layoutWidth={settingValues.layoutWidth}
-              graphTitle={settingValues.title}
-              />
-            </Button>
-            <Button>
-              <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
-            </Button>
-            <Button>Three</Button>
-          </ButtonGroup>
+//           <ButtonGroup variant="contained" aria-label="Basic button group">
+//             <Button>
+//               <DownloadImageButton 
+//               layoutHeight={settingValues.layoutHeight}  
+//               layoutWidth={settingValues.layoutWidth}
+//               graphTitle={settingValues.title}
+//               />
+//             </Button>
+//             <Button>
+//               <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
+//             </Button>
+//             <Button>Three</Button>
+//           </ButtonGroup>
 
-          <div className='join'>
-            <div>あああ</div>
-            <button class="btn join-item">Button</button>
-            <button class="btn join-item">Button</button>
-            <button onClick={handleDrawerOpen} className='btn btn-info join-item'>Right</button>
-          </div>
+//           <div className='join'>
+//             <div>あああ</div>
+//             <button class="btn join-item">Button</button>
+//             <button class="btn join-item">Button</button>
+//             <button onClick={handleDrawerOpen} className='btn btn-info join-item'>Right</button>
+//           </div>
 
 
           
 
 
-          {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
-          <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
+//           {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
+//           <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
 
-          {/* ここにグラフ */}
-          <div className='flex justify-center items-center bg-blue-200'>
-            <Graph sv={settingValues}/>
-          </div>
+//           {/* ここにグラフ */}
+//           <div className='flex justify-center items-center bg-blue-200'>
+//             <Graph sv={settingValues}/>
+//           </div>
 
-        </Main>
-        <Drawer
-          sx={{
-            position: 'relative',
-            marginLeft: "auto",
-            width: drawerWidth,
-            "& .MuiBackdrop-root": {
-              display: "none"
-            },
-            "& .MuiDrawer-paper": {
-              width: drawerWidth,
-              height: "100%",
-              position: "absolute",
-              backgroundColor: "limegreen",
-              display: "flex",
-              padding: "20px",
-              alignItems: "center",
-            }
-          }}
-          // className={[classes.drawer, 'text-3xl']}
-          variant="persistent"
-          anchor="right"
-          open={open}
-        > 
-          {/* ここからDrawerの中身 */}
-          <div>
-            <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
-          </div>
+//         </Main>
+//         <Drawer
+//           sx={{
+//             position: 'relative',
+//             marginLeft: "auto",
+//             width: drawerWidth,
+//             "& .MuiBackdrop-root": {
+//               display: "none"
+//             },
+//             "& .MuiDrawer-paper": {
+//               width: drawerWidth,
+//               height: "100%",
+//               position: "absolute",
+//               backgroundColor: "limegreen",
+//               display: "flex",
+//               padding: "20px",
+//               alignItems: "center",
+//             }
+//           }}
+//           // className={[classes.drawer, 'text-3xl']}
+//           variant="persistent"
+//           anchor="right"
+//           open={open}
+//         > 
+//           {/* ここからDrawerの中身 */}
+//           <div>
+//             <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
+//           </div>
 
-          {/* ここにグラフ設定値入力コンポーネント */}
-          <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
-          {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
+//           {/* ここにグラフ設定値入力コンポーネント */}
+//           <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
+//           {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
 
-        </Drawer>
-      </Box>
-      <BottomDrawer />      
-    </>
-  );
-}
+//         </Drawer>
+//       </Box>
+//       <BottomDrawer />      
+//     </>
+//   );
+// }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,14 +1,198 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { styled } from '@mui/material/styles';
+// import { makeStyles } from "@material-ui/core/styles";
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+
 import Graph from './components/graph/graph';
-import MainWithRightDrawer from './components/main_with_right_drawer';
 import BottomDrawer from './components/bottom_drawer';
+import GraphSettings from './components/graph_settings/graph_settings';
+import DownloadImageButton from './components/download_image/download_image_button';
+import MyGraphModal from './components/create_mygraph/mygraph_modal';
+import { useGraph } from './hooks/useGraph';
+
+const drawerWidth = 300;
+
+const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
+  ({ theme, open }) => ({
+    flexGrow: 1,
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    marginRight: -drawerWidth,
+    ...(open && {
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+      marginRight: 0,
+    }),
+    /**
+     * This is necessary to enable the selection of content. In the DOM, the stacking order is determined
+     * by the order of appearance. Following this rule, elements appearing later in the markup will overlay
+     * those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures
+     * proper interaction with the underlying content.
+     */
+    position: 'relative',
+  }),
+);
 
 export default function CanvasApp() {
+  const { graph, setGraph, loading } = useGraph();
+
+  const [open, setOpen] = useState(true);
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+
+  // GraphSettingsのstateとハンドラを宣言
+  const [lineDotSize, setLineDotSize] = useState(4); //useGraphでデータを取得するまでの初期値
+
+  const [settingValues, setSettingValues] = useState({
+    lineColor: '#FF0000',                  //線の色
+    lineWidth: 1.5,                          //線の太さ
+    dotOutlineColor: '#FF0000',            //ドットの外枠の色
+    dotFillColor: '#FFFFFF',               //ドットの塗りつぶしの色
+    dotSize: 4,                            //ドットのサイズ
+    dotOutlineWidth: 1,                    //ドットの外枠の太さ
+    tempMax: 40,                           //気温の目盛り最大値
+    tempMin: -30,                          //気温の目盛り最小値
+    scaleCount: 8,                         //目盛りの数（棒グラフと共通）
+    tempYAxisFontSize: 16,                 //Y軸目盛りのフォントサイズ
+    tempYAxisFontColor: '#000000',         //Y軸目盛りのフォントカラー
+    tempYAxisLineWidth: 1,                 //Y軸の線の太さ
+    tempYAxisLineColor: '#000000',         //Y軸の線のカラー
+
+    barFillColor: '#00FFFF',               //棒グラフの塗りつぶしの色
+    barOutlineColor: '#000000',            //棒グラフの外枠の色
+    barBinWidth: 30,                       //棒グラフの幅
+    barOutlineWidth: 1,                    //棒グラフの外枠の太さ
+    rainMax: 700,                          //降水量の目盛り最大値
+    rainYAxisFontSize: 16,                 //Y軸目盛りのフォントサイズ
+    rainYAxisFontColor: '#000000',         //Y軸目盛りのフォントカラー
+    rainYAxisLineWidth: 1,                 //Y軸の線の太さ
+    rainYAxisLineColor: '#000000',         //Y軸の線のカラー
+
+    xAxisFontSize: 12,                     //X軸目盛りのフォントサイズ
+    xAxisFontColor: '#000000',             //X軸目盛りのフォントカラー
+    xAxisLineWidth: 1,                     //X軸の線の太さ
+    xAxisLineColor: '#000000',             //X軸の線のカラー
+
+    title: '東京',                          //グラフタイトル
+    titleFontSize: 24,                     //グラフタイトルのフォントサイズ
+    titleFontColor: '#000000',             //グラフタイトルのフォントカラー
+
+    layoutHeight: 500,                     //グラフの高さ
+    layoutWidth: 500,                      //グラフの幅
+    marginTop: 50,                         //グラフの上マージン
+    marginBottom: 60,                      //グラフの下マージン
+    marginLeft: 20,                        //グラフの左マージン
+    marginRight: 20,                       //グラフの右マージン
+    backgroundColor: '#FFFFFF',            //グラフの背景色
+    fontfamily: 'sans-serif',              //フォントファミリー
+  });
+
+
+  //graphデータが取得できたら，state値を更新
+  useEffect(() => {
+    if (graph.graph_setting) {
+      setLineDotSize(graph.graph_setting.settings.dotSize);
+    }
+  }, [graph]);
+
+  //GraphSettingsコンポーネントに渡すハンドラ
+  const handleValueChange = (name, value) => {
+    setSettingValues({...settingValues, [name]: value});
+  }
+
+  // console.log('Graph Data from Backend!', graph);
+  // console.log('lineWidth :', settingValues.lineWidth);
+  console.log('fontFamily :', settingValues.fontfamily);
+  
+  if (loading) {
+    return <div>loading...</div>
+  }
 
   return (
-    <div className=''>
-      <MainWithRightDrawer />
+    <>
+      <Box sx={{ display: 'flex' }} className='bg-red-200'>
+        <Main open={open}>
+          
+          <ButtonGroup variant="contained" aria-label="Basic button group">
+            <Button>
+              <DownloadImageButton 
+              layoutHeight={settingValues.layoutHeight}  
+              layoutWidth={settingValues.layoutWidth}
+              graphTitle={settingValues.title}
+              />
+            </Button>
+            <Button>
+              <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
+            </Button>
+            <Button>Three</Button>
+          </ButtonGroup>
+
+          <div className='join'>
+            <div>あああ</div>
+            <button class="btn join-item">Button</button>
+            <button class="btn join-item">Button</button>
+            <button onClick={handleDrawerOpen} className='btn btn-info join-item'>Right</button>
+          </div>
+
+
+          
+
+
+          {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
+          <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
+
+          {/* ここにグラフ */}
+          <div className='flex justify-center items-center bg-blue-200'>
+            <Graph sv={settingValues}/>
+          </div>
+
+        </Main>
+        <Drawer
+          sx={{
+            position: 'relative',
+            marginLeft: "auto",
+            width: drawerWidth,
+            "& .MuiBackdrop-root": {
+              display: "none"
+            },
+            "& .MuiDrawer-paper": {
+              width: drawerWidth,
+              height: "100%",
+              position: "absolute",
+              backgroundColor: "limegreen",
+              display: "flex",
+              padding: "20px",
+              alignItems: "center",
+            }
+          }}
+          // className={[classes.drawer, 'text-3xl']}
+          variant="persistent"
+          anchor="right"
+          open={open}
+        > 
+          {/* ここからDrawerの中身 */}
+          <div>
+            <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
+          </div>
+
+          {/* ここにグラフ設定値入力コンポーネント */}
+          <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
+          {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
+
+        </Drawer>
+      </Box>
       <BottomDrawer />      
-    </div>
-  )
+    </>
+  );
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -41,15 +41,19 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
 );
 
 export default function CanvasApp() {
+  //グラフデータを取得するカスタムフック
   const { graph, setGraph, loading } = useGraph();
 
+  //右ドロワーの開閉状態を管理
   const [open, setOpen] = useState(true);
-  const handleDrawerOpen = () => {
-    setOpen(true);
-  };
-  const handleDrawerClose = () => {
-    setOpen(false);
-  };
+  const handleToggleDrawer = () => {
+    if (open) {
+      handleDrawerClose();
+    } else {
+      handleDrawerOpen();
+    }
+  }
+
 
   // GraphSettingsのstateとハンドラを宣言
   const [lineDotSize, setLineDotSize] = useState(4); //useGraphでデータを取得するまでの初期値
@@ -121,43 +125,47 @@ export default function CanvasApp() {
 
   return (
     <>
-      <Box sx={{ display: 'flex' }} className='bg-red-200'>
-        <Main open={open}>
-          
-          <ButtonGroup variant="contained" aria-label="Basic button group">
-            <Button>
-              <DownloadImageButton 
+      {/* 操作メニューバー */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          '& > *': {
+            m: 1,
+          },
+        }}
+      >
+        <ButtonGroup variant="contained" aria-label="Basic button group">
+          <Button>
+            <DownloadImageButton 
               layoutHeight={settingValues.layoutHeight}  
               layoutWidth={settingValues.layoutWidth}
               graphTitle={settingValues.title}
-              />
-            </Button>
-            <Button>
-              <MyGraphModal graphSetting={{dotSize: lineDotSize}}/>
-            </Button>
-            <Button>Three</Button>
-          </ButtonGroup>
+            />
+          </Button>
+          <Button> <MyGraphModal graphSetting={{dotSize: lineDotSize}}/> </Button>
+          <Button> <BottomDrawer /> </Button>
+          <Button onClick={handleToggleDrawer} >  settings  </Button>
+        </ButtonGroup>
+      </Box>
 
-          <div className='join'>
-            <div>あああ</div>
-            <button class="btn join-item">Button</button>
-            <button class="btn join-item">Button</button>
-            <button onClick={handleDrawerOpen} className='btn btn-info join-item'>Right</button>
-          </div>
+      {/* グラフ描画と右ドロワーをラップしたBox */}
+      <Box sx={{ display: 'flex' }} className='bg-red-200'>
 
-
-          
-
+        {/* open時に右ドロワーの幅だけ縮むMain */}
+        <Main open={open}>
 
           {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
           <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
 
-          {/* ここにグラフ */}
+          {/* Rechartsグラフ描画部分 */}
           <div className='flex justify-center items-center bg-blue-200'>
             <Graph sv={settingValues}/>
           </div>
-
         </Main>
+
+        {/* 右ドロワー */}
         <Drawer
           sx={{
             position: 'relative',
@@ -179,20 +187,17 @@ export default function CanvasApp() {
           // className={[classes.drawer, 'text-3xl']}
           variant="persistent"
           anchor="right"
-          open={open}
+          open={open}   //⭐closeに戻す！
         > 
-          {/* ここからDrawerの中身 */}
-          <div>
-            <div onClick={handleDrawerClose} className='btn btn-primary'>Close</div>
-          </div>
 
-          {/* ここにグラフ設定値入力コンポーネント */}
+          {/* グラフ設定値入力コンポーネント */}
           <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
           {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
 
         </Drawer>
       </Box>
-      <BottomDrawer />      
+      <div>ここにImage</div>
+      <img alt="" id="output" />
     </>
   );
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -12,6 +12,7 @@ import GraphSettings from './components/graph_settings/graph_settings';
 import DownloadImageButton from './components/download_image/download_image_button';
 import MyGraphModal from './components/create_mygraph/mygraph_modal';
 import { useGraph } from './hooks/useGraph';
+import { set } from 'react-hook-form';
 
 const drawerWidth = 300;
 
@@ -41,19 +42,27 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
 );
 
 export default function CanvasApp() {
-  //グラフデータを取得するカスタムフック
+  // Graphデータを取得するカスタムフック
   const { graph, setGraph, loading } = useGraph();
 
-  //右ドロワーの開閉状態を管理
-  const [open, setOpen] = useState(true);
-  const handleToggleDrawer = () => {
-    if (open) {
-      handleDrawerClose();
-    } else {
-      handleDrawerOpen();
-    }
-  }
+  // 右ドロワーのstateとハンドラを宣言
+  const [openRightDrawer, setOpenRightDrawer] = useState(true); //⭐falseに戻す！
+  const handleRightDrawer = () => { openRightDrawer ? setOpenRightDrawer(false) : setOpenRightDrawer(true) }
 
+  // 画像DLモーダルのstateとハンドラ
+  const [openDLImageModal, setOpenDLImageModal] = useState(false);
+  const handleOpenDLImageModal = () => setOpenDLImageModal(true);
+  const handleCloseDLImageModal = () => setOpenDLImageModal(false);
+
+  // マイグラフ登録モーダルのstateとハンドラ
+  const [openMyGraphModal, setOpenMyGraphModal] = useState(false);
+  const handleOpenMyGraphModal = () => setOpenMyGraphModal(true);
+  const handleCloseMyGraphModal = () => setOpenMyGraphModal(false);
+
+  // 下ドロワーのstateとハンドラ
+  const [openBottomDrawer, setOpenBottomDrawer] = useState(false);
+  const handleOpenBottomDrawer = () => setOpenBottomDrawer(true);
+  const handleCloseBottomDrawer = () => setOpenBottomDrawer(false);
 
   // GraphSettingsのstateとハンドラを宣言
   const [lineDotSize, setLineDotSize] = useState(4); //useGraphでデータを取得するまでの初期値
@@ -117,7 +126,7 @@ export default function CanvasApp() {
 
   // console.log('Graph Data from Backend!', graph);
   // console.log('lineWidth :', settingValues.lineWidth);
-  console.log('fontFamily :', settingValues.fontfamily);
+  // console.log('fontFamily :', settingValues.fontfamily);
   
   if (loading) {
     return <div>loading...</div>
@@ -137,24 +146,33 @@ export default function CanvasApp() {
         }}
       >
         <ButtonGroup variant="contained" aria-label="Basic button group">
-          <Button>
-            <DownloadImageButton 
-              layoutHeight={settingValues.layoutHeight}  
-              layoutWidth={settingValues.layoutWidth}
-              graphTitle={settingValues.title}
-            />
-          </Button>
-          <Button> <MyGraphModal graphSetting={{dotSize: lineDotSize}}/> </Button>
-          <Button> <BottomDrawer /> </Button>
-          <Button onClick={handleToggleDrawer} >  settings  </Button>
+          <Button onClick={handleOpenDLImageModal}>画像DL</Button>
+          <Button onClick={handleOpenMyGraphModal}>マイグラフ保存</Button>
+          <Button onClick={handleOpenBottomDrawer}> 都市データ </Button>
+          <Button onClick={handleRightDrawer} >  settings  </Button>
         </ButtonGroup>
       </Box>
+
+        {/* 画像DLモーダル */}
+        <DownloadImageButton 
+          layoutHeight={settingValues.layoutHeight}  
+          layoutWidth={settingValues.layoutWidth}
+          graphTitle={settingValues.title}
+          open={openDLImageModal}
+          handleClose={handleCloseDLImageModal}
+        />
+
+        {/* マイグラフ登録モーダル */}
+        <MyGraphModal 
+          graphSetting={{dotSize: lineDotSize}}
+          open={openMyGraphModal}
+          handleClose={handleCloseMyGraphModal} />
 
       {/* グラフ描画と右ドロワーをラップしたBox */}
       <Box sx={{ display: 'flex' }} className='bg-red-200'>
 
-        {/* open時に右ドロワーの幅だけ縮むMain */}
-        <Main open={open}>
+        {/* open時に右ドロワーの幅だけ縮むMain描画部分 */}
+        <Main open={openRightDrawer}>
 
           {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
           <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
@@ -187,15 +205,17 @@ export default function CanvasApp() {
           // className={[classes.drawer, 'text-3xl']}
           variant="persistent"
           anchor="right"
-          open={open}   //⭐closeに戻す！
+          open={openRightDrawer}
         > 
 
           {/* グラフ設定値入力コンポーネント */}
           <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
           {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
-
         </Drawer>
       </Box>
+
+      {/* 下ドロワー */}
+      <BottomDrawer open={openBottomDrawer} handleClose={handleCloseBottomDrawer}/>
       <div>ここにImage</div>
       <img alt="" id="output" />
     </>

--- a/app/views/canvas/index.html.slim
+++ b/app/views/canvas/index.html.slim
@@ -3,4 +3,4 @@
 .w-full
   .mx-auto
     .flex.justify-center
-      | test
+      | footer


### PR DESCRIPTION
次のissueの項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/116

- 下準備として，これまでメイン画面上部をになっていたmain_with_right_drawerコンポーネントを，indexに移管しました。これに伴って，メイン画面にて扱うコンポーネントと，連動させるstateやハンドラは，新しいindexに集中管理される形となります。
- 画像DL・マイグラフ登録・下ドロワーの各コンポーネントから，開閉を制御するstateとハンドラを分離し，indexに集約しました
- 各コンポーネントは，ドロワーやモーダルの描画部分に専念することになります
- 画面上部に，MaterialUIのButtonGroupを用いた制御バーを作りました

close #116 

https://i.gyazo.com/eb1e66851da72c1dbd7560532d4e3726.gif