### PR TITLE
マイグラフ一覧で選択したグラフを，canvas画面で表示する

### DIFF
--- a/app/javascript/react/canvas/hooks/useGraph.js
+++ b/app/javascript/react/canvas/hooks/useGraph.js
@@ -1,27 +1,31 @@
 import { useState, useEffect } from 'react';
 
-export const useGraph = () => {
-  const [graph, setGraph] = useState([]);
-  const [loading, setLoading] = useState(true);
+export const useGraph = (param) => {            //引数はgraphParamを受ける
+  const [graph, setGraph] = useState([]);       //初期値は空の配列
+  const [loading, setLoading] = useState(true); //fetch完了まで描画してはいけないのでloadingをtrueに
 
-  useEffect(() => {
-    async function fetchGraph() {
+  useEffect(() => {                             //useEffectはレンダリング完了時に実行される
+    async function fetchGraph(param) {          //ここからfetch関数を定義。
+      console.log('param: ', param)
       try {
-        const response = await fetch('/api/graphs/6');
+        const response = await fetch(`/api/graphs/${param}`);   //api/graphs/:idにfetchリクエストを送る（showアクション）
         if (response.ok) {
           const graph = await response.json();
-          setGraph(graph);
-          setLoading(false);
+          console.log(graph)
+          setGraph(graph);  //取得したgraphデータをstateにセット
+          setLoading(false); //fetch完了したのでloadingをfalseに
         } else {
           console.log('server error!');
+          setLoading(false);  //fetch処理は完了したのでloadingをfalseに
         }
       } catch (error) {
           console.log('failed to fetch', error);
+          setLoading(false);
       }
     }
 
-    fetchGraph();
-  }, [])
+    fetchGraph(param);    //上で定義したfetch関数を実行
+  }, []);                 //useEffectここまで。第二引数に空の配列を渡すことで、初回レンダリング時のみfetchを実行する
 
-  return { graph, setGraph, loading }
+  return { graph, loading }   //fetchしたgraphデータとloadingのstateを返す
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+
 import { styled } from '@mui/material/styles';
 // import { makeStyles } from "@material-ui/core/styles";
 import Box from '@mui/material/Box';
@@ -42,8 +43,6 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
 );
 
 export default function CanvasApp() {
-  // Graphデータを取得するカスタムフック
-  const { graph, setGraph, loading } = useGraph();
 
   // 右ドロワーのstateとハンドラを宣言
   const [openRightDrawer, setOpenRightDrawer] = useState(true); //⭐falseに戻す！
@@ -111,18 +110,32 @@ export default function CanvasApp() {
     fontfamily: 'sans-serif',              //フォントファミリー
   });
 
+  //GraphSettingsコンポーネントに渡す設定値更新ハンドラ（対象のみ更新する）
+  const handleValueChange = (name, value) => {
+    setSettingValues({...settingValues, [name]: value});
+  }
+
+  // 現在のURLを取得
+  const url = new URL(window.location.href);
+  // URLSearchParamsオブジェクトを取得
+  const params = new URLSearchParams(url.search);
+  // グラフパラメータを取得
+  const graphParam = params.get('graph'); // 'paramName'を取得したいクエリパラメータ名に置き換えます
+  console.log('graphParam: ', graphParam);
+
+  // Graphデータを取得するカスタムフック
+    //graphはfetchしたデータ，fetchが完了するまでloadingはtrue
+  const { graph, loading } = useGraph(graphParam);
 
   //graphデータが取得できたら，state値を更新
   useEffect(() => {
     if (graph.graph_setting) {
-      setLineDotSize(graph.graph_setting.settings.dotSize);
+      // setLineDotSize(graph.graph_setting.settings.dotSize);
+      setSettingValues(graph.graph_setting.settings);
     }
-  }, [graph]);
+  }, [graph]); //第二引数にgraphを指定することで，graphデータが更新された時のみuseEffectを実行
 
-  //GraphSettingsコンポーネントに渡すハンドラ
-  const handleValueChange = (name, value) => {
-    setSettingValues({...settingValues, [name]: value});
-  }
+
 
   // console.log('Graph Data from Backend!', graph);
   // console.log('lineWidth :', settingValues.lineWidth);

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -32,7 +32,7 @@
             td.px-6.py-4.text-sm
               = graph.note
             td.px-2.py-4 
-              = link_to '編集', "#", class: 'text-blue-500'
+              = link_to '編集', canvas_path(graph: graph.id), class: 'text-blue-500'
             td.px-2.py-4 
               = link_to '削除', "#", class: 'text-red-500'
 


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/55

- マイグラフ一覧の「編集」ボタンで，canvas_pathへのlinkに当該graphのidを，パラメータとして加えました
- index.jsxに，現在のURLを取得し，パラメータをgetする処理を実装しました
- graphパラメータをgetできた場合，その取得したid値をuseGraphフックに引数として渡すことで，api/graph/:id の:id値を動的に変化させてfetchすることができるようにしました
- issueにある一連の流れはテスト済みです。
- ただし，条件分岐をさせていないため，現状では全てのアクセスでgraphパラメータを取得しようとします

close #55 