### PR TITLE
Reactにログイン中であるかどうかを認識させる・グラフデータが揃ってから描画を開始する

### DIFF
--- a/app/controllers/api/user_sessions_controller.rb
+++ b/app/controllers/api/user_sessions_controller.rb
@@ -1,0 +1,5 @@
+class Api::UserSessionsController < Api::BaseController
+  def check_login
+    render json: { login: logged_in? }
+  end
+end

--- a/app/controllers/api/user_sessions_controller.rb
+++ b/app/controllers/api/user_sessions_controller.rb
@@ -1,5 +1,5 @@
 class Api::UserSessionsController < Api::BaseController
   def check_login
-    render json: { login: logged_in? }
+    render json: { logged_in: logged_in? }
   end
 end

--- a/app/javascript/react/canvas/hooks/checkLoggedIn.js
+++ b/app/javascript/react/canvas/hooks/checkLoggedIn.js
@@ -9,6 +9,7 @@ export const checkLoggedIn = () => {
       try {
         const response = await fetch('/api/check_login');
         if (response.ok) {
+          console.log('checkLoggedInです。response.okを受け取りました')
           const data = await response.json();
           if (data.logged_in) {
             setLoggedIn(true);  //ログイン状態をtrueに

--- a/app/javascript/react/canvas/hooks/checkLoggedIn.js
+++ b/app/javascript/react/canvas/hooks/checkLoggedIn.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+export const checkLoggedIn = () => {
+  const [loggedIn, setLoggedIn] = useState(false); //ログイン状態を管理するstateを宣言
+  const [loginCheckLoading, setLoginCheckLoading] = useState(true); //ログインチェック中状態を管理するstateを宣言
+
+  useEffect(() => {                   //useEffectはレンダリング完了時に実行される
+    async function fetchLoggedIn() {  //ここからfetch関数を定義。
+      try {
+        const response = await fetch('/api/check_login');
+        if (response.ok) {
+          const data = await response.json();
+          if (data.logged_in) {
+            setLoggedIn(true);  //ログイン状態をtrueに
+            console.log('check logged in ;)');
+          } else {
+            console.log('not logged in :(');
+          }
+        } else {
+          console.log('server error!');
+        }
+      } catch (error) {
+        console.log('failed to fetch', error);
+      } finally {
+        setLoginCheckLoading(false);  //fetch終了時にローディング状態をfalseに
+      }
+    }
+    fetchLoggedIn();   //上で定義したfetch関数を実行
+  }, []);
+  // console.log('loggedIn:', loggedIn, ' loginCheckLoading:',  loginCheckLoading)
+  return { loggedIn, loginCheckLoading };    //ログイン状態を返す
+}

--- a/app/javascript/react/canvas/hooks/useGraph.js
+++ b/app/javascript/react/canvas/hooks/useGraph.js
@@ -9,58 +9,39 @@ export const useGraph = (
   const [graphLoading, setGraphLoading] = useState(true);   //ここのローディング状態を管理するstate
 
   useEffect(() => {                             //useEffectはレンダリング完了時に実行される
-    // console.log('param:', param, ' loginCheckLoading:', loginCheckLoading, ' loggedIn:', loggedIn);
     
     if (loginCheckLoading) {   
-      console.log('ログインチェック中のためreturnします')                 //ログインチェック中の場合は，何もせず即リターン
-      return
+      console.log('useGraphです。ログインチェック中のためreturnします')                 //ログインチェック中の場合は，何もせず即リターン
+      return;
     }
 
     if (!loggedIn) {              //ログインしていない場合は，ここのローディング状態をfalseにするだけで即リターン
-      console.log('ログインしていないのでreturnします')
+      console.log('useGraphです。ログインしていないのでreturnします')
       setGraphLoading(false);
-      return
+      return;
     }
 
     if (!param) {     //ログインしているが，graphParamがnullの場合は，ここのローディング状態をfalseにするだけで即リターン
-      console.log('graphParamがnullなのでreturnします')
+      console.log('useGraphです。graphParamがnullなのでreturnします')
       setGraphLoading(false);
-      return
+      return;
     }
 
     async function fetchGraph(param) {         //ここからfetch関数を定義。
       try{
         const response = await fetch(`/api/graphs/${param}`);   //api/graphs/:idにfetchリクエストを送る（showアクション）
         if (response.ok) {
+          console.log('useGraphです。response.okを受け取りました')
           const graph = await response.json();
           setGraph(graph);  //取得したgraphデータをstateにセット
-          // console.log('setしたgraph:', graph)
         }
       } catch (error) {
-        console.log('failed to fetch', error);
+        console.log('graphデータのfetchに失敗しました。', error);
       } finally {
         setGraphLoading(false);  //fetch終了時にローディング状態をfalseに
       }
     }
-    // console.log('ここまできてる？')
-    // //ここまで来た場合は，ログインしていて，graphParamがnullでない場合
-    // async function fetchGraph(param) {         //ここからfetch関数を定義。
-    //   try {
-    //     const response = await fetch(`/api/graphs/${param}`);   //api/graphs/:idにfetchリクエストを送る（showアクション）
-    //     if (response.ok) {
-    //       const graph = await response.json();
-    //       setGraph(graph);  //取得したgraphデータをstateにセット
-    //       console.log('setしたgraph:', graph)
-    //     } else {
-    //       console.log('server error!');
-    //     }
-    //   } catch (error) {
-    //       console.log('failed to fetch', error);
-    //   } finally {
-    //     setGraphLoading(false);  //fetch終了時にローディング状態をfalseに
-    //   }
-    // }
-    // console.log("ここにもきてる？？")
+    console.log('useGraphです。fetchGraphを実行します')
     fetchGraph(param);    //上で定義したfetch関数を実行
   }, [param, loginCheckLoading, loggedIn]);            //paramとloginCheckLoadingが変更されたことを監視
 

--- a/app/javascript/react/canvas/hooks/useGraph.js
+++ b/app/javascript/react/canvas/hooks/useGraph.js
@@ -1,31 +1,68 @@
 import { useState, useEffect } from 'react';
 
-export const useGraph = (param) => {            //引数はgraphParamを受ける
-  const [graph, setGraph] = useState([]);       //初期値は空の配列
-  const [loading, setLoading] = useState(true); //fetch完了まで描画してはいけないのでloadingをtrueに
+export const useGraph = (
+  param,
+  loginCheckLoading,
+  loggedIn ) => {               //引数にgraphParamと，ログインチェック中状態，ログイン状態を受け取る
+  
+  const [graph, setGraph] = useState(null);        //初期値は空の配列
+  const [graphLoading, setGraphLoading] = useState(true);   //ここのローディング状態を管理するstate
 
   useEffect(() => {                             //useEffectはレンダリング完了時に実行される
-    async function fetchGraph(param) {          //ここからfetch関数を定義。
-      console.log('param: ', param)
-      try {
+    // console.log('param:', param, ' loginCheckLoading:', loginCheckLoading, ' loggedIn:', loggedIn);
+    
+    if (loginCheckLoading) {   
+      console.log('ログインチェック中のためreturnします')                 //ログインチェック中の場合は，何もせず即リターン
+      return
+    }
+
+    if (!loggedIn) {              //ログインしていない場合は，ここのローディング状態をfalseにするだけで即リターン
+      console.log('ログインしていないのでreturnします')
+      setGraphLoading(false);
+      return
+    }
+
+    if (!param) {     //ログインしているが，graphParamがnullの場合は，ここのローディング状態をfalseにするだけで即リターン
+      console.log('graphParamがnullなのでreturnします')
+      setGraphLoading(false);
+      return
+    }
+
+    async function fetchGraph(param) {         //ここからfetch関数を定義。
+      try{
         const response = await fetch(`/api/graphs/${param}`);   //api/graphs/:idにfetchリクエストを送る（showアクション）
         if (response.ok) {
           const graph = await response.json();
-          console.log(graph)
           setGraph(graph);  //取得したgraphデータをstateにセット
-          setLoading(false); //fetch完了したのでloadingをfalseに
-        } else {
-          console.log('server error!');
-          setLoading(false);  //fetch処理は完了したのでloadingをfalseに
+          // console.log('setしたgraph:', graph)
         }
       } catch (error) {
-          console.log('failed to fetch', error);
-          setLoading(false);
+        console.log('failed to fetch', error);
+      } finally {
+        setGraphLoading(false);  //fetch終了時にローディング状態をfalseに
       }
     }
-
+    // console.log('ここまできてる？')
+    // //ここまで来た場合は，ログインしていて，graphParamがnullでない場合
+    // async function fetchGraph(param) {         //ここからfetch関数を定義。
+    //   try {
+    //     const response = await fetch(`/api/graphs/${param}`);   //api/graphs/:idにfetchリクエストを送る（showアクション）
+    //     if (response.ok) {
+    //       const graph = await response.json();
+    //       setGraph(graph);  //取得したgraphデータをstateにセット
+    //       console.log('setしたgraph:', graph)
+    //     } else {
+    //       console.log('server error!');
+    //     }
+    //   } catch (error) {
+    //       console.log('failed to fetch', error);
+    //   } finally {
+    //     setGraphLoading(false);  //fetch終了時にローディング状態をfalseに
+    //   }
+    // }
+    // console.log("ここにもきてる？？")
     fetchGraph(param);    //上で定義したfetch関数を実行
-  }, []);                 //useEffectここまで。第二引数に空の配列を渡すことで、初回レンダリング時のみfetchを実行する
+  }, [param, loginCheckLoading, loggedIn]);            //paramとloginCheckLoadingが変更されたことを監視
 
-  return { graph, loading }   //fetchしたgraphデータとloadingのstateを返す
+  return { graph, graphLoading }   //fetchしたgraphデータを返す
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -13,7 +13,7 @@ import GraphSettings from './components/graph_settings/graph_settings';
 import DownloadImageButton from './components/download_image/download_image_button';
 import MyGraphModal from './components/create_mygraph/mygraph_modal';
 import { useGraph } from './hooks/useGraph';
-import { set } from 'react-hook-form';
+import { checkLoggedIn } from './hooks/checkLoggedIn';
 
 const drawerWidth = 300;
 
@@ -43,7 +43,6 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
 );
 
 export default function CanvasApp() {
-
   // 右ドロワーのstateとハンドラを宣言
   const [openRightDrawer, setOpenRightDrawer] = useState(true); //⭐falseに戻す！
   const handleRightDrawer = () => { openRightDrawer ? setOpenRightDrawer(false) : setOpenRightDrawer(true) }
@@ -64,7 +63,6 @@ export default function CanvasApp() {
   const handleCloseBottomDrawer = () => setOpenBottomDrawer(false);
 
   // GraphSettingsのstateとハンドラを宣言
-  const [lineDotSize, setLineDotSize] = useState(4); //useGraphでデータを取得するまでの初期値
   //GraphSettingsのstate値をまとめて初期化。GraphやTemplateを取得した場合は，useEffectで更新する
   const [settingValues, setSettingValues] = useState({
     lineColor: '#FF0000',                  //線の色
@@ -115,38 +113,47 @@ export default function CanvasApp() {
     setSettingValues({...settingValues, [name]: value});
   }
 
-  // 現在のURLを取得
-  const url = new URL(window.location.href);
-  // URLSearchParamsオブジェクトを取得
-  const params = new URLSearchParams(url.search);
-  // グラフパラメータを取得
-  const graphParam = params.get('graph'); // 'paramName'を取得したいクエリパラメータ名に置き換えます
-  console.log('graphParam: ', graphParam);
+  //ログイン状態をチェック
+  const { loggedIn, loginCheckLoading } = checkLoggedIn();
+  console.log('loggedIn: ', loggedIn, ' loginCheckLoading: ', loginCheckLoading);
 
-  // Graphデータを取得するカスタムフック
-    //graphはfetchしたデータ，fetchが完了するまでloadingはtrue
-  const { graph, loading } = useGraph(graphParam);
+  const url = new URL(window.location.href);      // 現在のURLを取得
+  const params = new URLSearchParams(url.search);    // URLSearchParamsオブジェクトを取得
+  const graphParam = params.get('graph');     // グラフパラメータを取得
 
-  //graphデータが取得できたら，state値を更新
+  const { graph, graphLoading } = useGraph(graphParam, loginCheckLoading, loggedIn);
+  console.log('graph:', graph, ' graphLoading:', graphLoading);
+  
+  
   useEffect(() => {
-    if (graph.graph_setting) {
-      // setLineDotSize(graph.graph_setting.settings.dotSize);
+    console.log('こちらはindexのuseEffect, graph: ', graph, 'graphLoading: ', graphLoading)
+    if (graph && graph.graph_setting) {
       setSettingValues(graph.graph_setting.settings);
     }
-  }, [graph]); //第二引数にgraphを指定することで，graphデータが更新された時のみuseEffectを実行
+  }, [graph, graphLoading]);
 
+  // graphデータが更新されたとき，useEffectでsettingValuesを更新
+  // useEffect(() => {
+  //   if (loggedIn && graphParam ) {
+  //     if (!graphLoading && graph) {     //グラフのローディングが終了しており，graphデータがnullでない場合
+  //       if (graph.graph_setting) {      //graphデータにgraph_settingがちゃんとある
+  //         setSettingValues(graph.graph_setting.settings);
+  //       }
+  //       setLoading(false);              //ログイン中だが，上記以外の条件はローディングを解除してよい
+  //     }
+  //   } else {
+  //     setLoading(false);          //そもそもログインしていないのでローディングを解除してよい
+  //   }
+  // }, [graph]);
 
-
-  // console.log('Graph Data from Backend!', graph);
-  // console.log('lineWidth :', settingValues.lineWidth);
-  // console.log('fontFamily :', settingValues.fontfamily);
-  
-  if (loading) {
-    return <div>loading...</div>
+  if ( loginCheckLoading || graphLoading) {
+    console.log('show loading')
+    return <div className='m-20'>loading...</div>
   }
 
   return (
     <>
+      <div>{ loggedIn ? 'あああああ' : 'いいいいい' }</div>
       {/* 操作メニューバー */}
       <Box
         sx={{

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -115,40 +115,23 @@ export default function CanvasApp() {
 
   //ログイン状態をチェック
   const { loggedIn, loginCheckLoading } = checkLoggedIn();
-  console.log('loggedIn: ', loggedIn, ' loginCheckLoading: ', loginCheckLoading);
 
   const url = new URL(window.location.href);      // 現在のURLを取得
   const params = new URLSearchParams(url.search);    // URLSearchParamsオブジェクトを取得
   const graphParam = params.get('graph');     // グラフパラメータを取得
 
-  const { graph, graphLoading } = useGraph(graphParam, loginCheckLoading, loggedIn);
-  console.log('graph:', graph, ' graphLoading:', graphLoading);
-  
+  const { graph, graphLoading } = useGraph(graphParam, loginCheckLoading, loggedIn);  
   
   useEffect(() => {
-    console.log('こちらはindexのuseEffect, graph: ', graph, 'graphLoading: ', graphLoading)
+    console.log('こちらはindexのuseEffectです。loggedIn: ', loggedIn, 'loginCheckLoading: ', loginCheckLoading, 'graph: ', graph,  'graphLoading: ', graphLoading)
     if (graph && graph.graph_setting) {
       setSettingValues(graph.graph_setting.settings);
     }
   }, [graph, graphLoading]);
 
-  // graphデータが更新されたとき，useEffectでsettingValuesを更新
-  // useEffect(() => {
-  //   if (loggedIn && graphParam ) {
-  //     if (!graphLoading && graph) {     //グラフのローディングが終了しており，graphデータがnullでない場合
-  //       if (graph.graph_setting) {      //graphデータにgraph_settingがちゃんとある
-  //         setSettingValues(graph.graph_setting.settings);
-  //       }
-  //       setLoading(false);              //ログイン中だが，上記以外の条件はローディングを解除してよい
-  //     }
-  //   } else {
-  //     setLoading(false);          //そもそもログインしていないのでローディングを解除してよい
-  //   }
-  // }, [graph]);
-
   if ( loginCheckLoading || graphLoading) {
     console.log('show loading')
-    return <div className='m-20'>loading...</div>
+    return <div className='m-20.text-3xl'>loading...</div>
   }
 
   return (

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :graphs, only: %i[index show create]
+    get "check_login", to: "user_sessions#check_login"
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
次のissueの項目を完了しました。
https://github.com/g-sawada/u-on-zu/issues/121

- useEffectを用いるcheckLoggedIn.jsを作成し，Rails側に作成した api/user_sessionsコントローラーのcheck_loginアクションに対して，ログイン状態を確認するfetch処理を非同期で実装しました。
- 上記のログインチェック処理が完了するまでは，メイン画面が描画されないように，仮のローディング画面を描画するように条件分岐させました。ログインチェックが完了しているかどうかは，ステート値loginCheckLoading　で管理しています。
- また，以前にuseGraphカスタムフックで実装したグラフデータのfetchが，必要なときにだけ実行されるように変更しました。①ログインチェックが終了しており，②ログイン中であり，③graphParamが取得できたとき，だけ，データフェッチを行うようにしました
- 「グラフデータのフェッチ処理の必要性がないとき」，または，「データフェッチが完了した後」にローディング画面を解除するようにしました。useGraphのステート値graphLoadingで管理し，JSXのrenderの条件分岐に加えています


close #121 
