### PR TITLE
CityとGraphの関連付け・機能連携

### DIFF
--- a/app/controllers/api/graphs_controller.rb
+++ b/app/controllers/api/graphs_controller.rb
@@ -30,6 +30,6 @@ class Api::GraphsController < Api::BaseController
 
   private
   def graph_params
-    params.require(:graph).permit(:title, :note, graph_setting: {})
+    params.require(:graph).permit(:title, :note, :city_id, graph_setting: {})
   end
 end

--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -15,7 +15,7 @@ const style = {
   p: 4,
 };
 
-export default function MyGraphModal({ graphSetting, open, handleClose }) {
+export default function MyGraphModal({ graphSetting, cityId, open, handleClose }) {
 
   const {       //フォームの設定。register, handleSubmit, resetはuseFormから取得できる
     register,
@@ -60,6 +60,7 @@ export default function MyGraphModal({ graphSetting, open, handleClose }) {
           title,
           note,
           graph_setting: graphSetting,
+          city_id: cityId,
         },
       }),
     })

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -148,6 +148,8 @@ export default function CanvasApp() {
       setSettingValues({...settingValues, title: city.name});   //グラフ設定値のタイトルの初期値を都市名に設定
     }
     if (graph && graph.graph_setting) {
+      console.log('graphのcity_id:', graph.graph.city_id)
+      setCityId(graph.graph.city_id);
       setSettingValues(graph.graph_setting.settings);
     }
   }, [graph, graphLoading, city, cityLoading]);

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -195,8 +195,8 @@ export default function CanvasApp() {
 
         {/* マイグラフ登録モーダル */}
         <MyGraphModal 
-          // graphSetting={{dotSize: lineDotSize}}
           graphSetting={settingValues}
+          cityId={cityId}
           open={openMyGraphModal}
           handleClose={handleCloseMyGraphModal} />
 

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,4 +1,6 @@
 class City < ApplicationRecord
+  has_many :graphs
+
   validates :name, presence: true
   validates :data, presence: true
 end

--- a/app/models/graph.rb
+++ b/app/models/graph.rb
@@ -1,4 +1,5 @@
 class Graph < ApplicationRecord
   belongs_to :user
+  belongs_to :city
   has_one :graph_setting, as: :metadata, dependent: :destroy
 end

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -24,7 +24,7 @@
             td.px-6.py-4.font-semibold
               = link_to graph.title, graph_path(graph)
             td.px-6.py-4
-              | 東京
+              = graph.city.name
             td.px-6.py-4
               | 日本
             td.px-6.py-4

--- a/db/migrate/20240524061918_add_city_to_graphs.rb
+++ b/db/migrate/20240524061918_add_city_to_graphs.rb
@@ -1,0 +1,15 @@
+class AddCityToGraphs < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :graphs, :city, foreign_key: true   #一度null: falseなしで追加
+
+    # 既存のGraphレコードにCityを紐付けるため、Cityの最初のレコードを取得
+    default_city = City.first
+    Graph.update_all(city_id: default_city.id)
+
+    change_column_null :graphs, :city_id, false  #null: falseを追加
+  end
+
+  def down
+    remove_reference :graphs, :city, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_23_034302) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_24_061918) do
   create_table "cities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.json "data", null: false
@@ -33,6 +33,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_034302) do
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "city_id", null: false
+    t.index ["city_id"], name: "index_graphs_on_city_id"
     t.index ["user_id"], name: "index_graphs_on_user_id"
   end
 
@@ -55,6 +57,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_034302) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "graphs", "cities"
   add_foreign_key "graphs", "users"
   add_foreign_key "templates", "users"
 end


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/130


- graphsテーブルに外部キーcity_idを追加しました。既存データには，id 1を仮であてることにしました。
- CityがGraphをhas_manyで持つ関連付けを設定しました。dependent: destroyは，cityのseedを更新することをかんがえてつけませんでした。
- マイグラフ保存実行時に送られるデータとして，city_idを追加しました。ステート値cityIdを代入して実現しています。
- マイグラフ一覧からcanvasに遷移し，useGraphでgraphデータがfetchできたとき，graphデータが持つcity_idを用いてcityIdを更新し，都市データをさらにfetchするようにしました。
- 上記のようにして，マイグラフと都市データとの機能連携を完成させています
- マイグラフ一覧ページの「都市」欄も，データに基づくように変更しました。

close #130 