### PR TITLE
マイグレーションファイル編集

### DIFF
--- a/db/migrate/20240524061918_add_city_to_graphs.rb
+++ b/db/migrate/20240524061918_add_city_to_graphs.rb
@@ -2,9 +2,8 @@ class AddCityToGraphs < ActiveRecord::Migration[7.1]
   def up
     add_reference :graphs, :city, foreign_key: true   #一度null: falseなしで追加
 
-    # 既存のGraphレコードにCityを紐付けるため、Cityの最初のレコードを取得
-    default_city = City.first
-    Graph.update_all(city_id: default_city.id)
+    # 既存のグラフデフォルトのid1を設定
+    Graph.update_all(city_id: 1)
 
     change_column_null :graphs, :city_id, false  #null: falseを追加
   end


### PR DESCRIPTION
グラフにcity_idを追加するマイグレーションにおいて，既存グラフがある場合の初期値をCity.firstではなく1にした

```

class AddCityToGraphs < ActiveRecord::Migration[7.1]
  def up
    add_reference :graphs, :city, foreign_key: true   #一度null: falseなしで追加

    # 既存のグラフデフォルトのid1を設定
    Graph.update_all(city_id: 1)

    change_column_null :graphs, :city_id, false  #null: falseを追加
  end

  def down
    remove_reference :graphs, :city, foreign_key: true
  end
end

```
