### PR TITLE
マイテンプレート保存機能

### DIFF
--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -1,0 +1,35 @@
+class Api::TemplatesController < Api::BaseController
+  # GET /api/templates
+  # テスト表示用
+  def index
+    graphs = Template.all
+    render json: { message: 'Hello, World!', templates: templates }
+  end
+
+  # GET /api/templates/:id
+  def show
+    graph = Template.find(params[:id])
+    render json: { template: template, graph_setting: template.graph_setting }
+  end
+
+  # POST /api/templates
+  def create
+    ActiveRecord::Base.transaction do
+      template = current_user.templates.new(template_params.except(:graph_setting))
+      graph_setting = template.build_graph_setting(settings: template_params[:graph_setting])
+
+      if template.save && graph_setting.save
+        render json: { template: template, graph_setting: graph_setting }, status: :ok
+      else
+        raise ActiveRecord::Rollback
+      end
+    end
+  rescue ActiveRecord::Rollback
+    render json: { error: '保存に失敗しました' }, status: :unprocessable_entity
+  end
+
+  private
+  def template_params
+    params.require(:template).permit(:title, graph_setting: {})
+  end
+end

--- a/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import Box from '@mui/material/Box';
+import Modal from '@mui/material/Modal';
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+};
+
+export default function MyTemplateModal({ graphSetting, open, handleClose }) {
+  const {       //フォームの設定。register, handleSubmit, resetはuseFormから取得できる
+    register,
+    handleSubmit,
+    reset,
+    // formState: { errors },
+  } = useForm();
+
+  const [serverError, setServerError] = useState(''); //サーバーエラーのステート
+
+  //⭐ フォームの送信処理
+  const onSubmit = async (data) => {
+    try {
+      const response = await createTemplate(  //バックへPOSTリクエスト, 後ろで定義
+        data.title,
+      )
+      if (response.ok) {
+        const responseData = await response.json();
+        console.log('送信リクエスト完了！')
+        console.log('responseData : ', responseData);
+        reset();       //フォームのリセット
+        handleClose();  //モーダルを閉じる
+      } else {
+        // setServerError('サーバーエラーが発生しました。');
+        console.log('サーバーエラーが発生しました。');
+      }
+    } catch (error) {
+      setServerError('リクエスト中にエラーが発生しました。');
+    }
+  }
+
+  // onSubmitで呼ばれるバックへの送信処理
+  const createTemplate = async (title) => {
+    const sendingGraphSetting = graphSetting // titleを空欄にするため，一旦graphSettingをコピー
+    sendingGraphSetting.title = ""           // titleを空欄にする
+    
+    const response = await fetch('/api/templates', {  //エンドポイントは/api/graphsのPOST → api/graphsコントローラーのcreateアクションを参照
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        graph: {
+          title,
+          graph_setting: sendingGraphSetting,
+          city_id: cityId,
+        },
+      }),
+    })
+    return response;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box className="" sx={style}>
+        <div className="container">
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
+            <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイテンプレート保存</h2>
+            {/* エラーメッセージ表示部分 */}
+            {/* <ErrorMessage message={serverError} />
+            <ErrorMessage message={errors.title?.message || ''} /> */}
+            
+            {/* Title */}
+            <label htmlFor="title" className="mb-2 text-lg">
+              テンプレートタイトル
+            </label>
+            <input
+              {...register('title', { required: 'Titleを入力して下さい。' })}
+              className="input input-bordered mb-5"
+            />
+            <button type="submit" className="btn mt-2">
+              マイテンプレート保存
+            </button>
+          </form>
+        </div>
+      </Box>
+    </Modal>
+  )
+}
+

--- a/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
@@ -50,17 +50,15 @@ export default function MyTemplateModal({ graphSetting, open, handleClose }) {
   const createTemplate = async (title) => {
     const sendingGraphSetting = graphSetting // titleを空欄にするため，一旦graphSettingをコピー
     sendingGraphSetting.title = ""           // titleを空欄にする
-    
     const response = await fetch('/api/templates', {  //エンドポイントは/api/graphsのPOST → api/graphsコントローラーのcreateアクションを参照
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        graph: {
+        template: {
           title,
           graph_setting: sendingGraphSetting,
-          city_id: cityId,
         },
       }),
     })

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -17,6 +17,7 @@ import BottomDrawer from './components/fetch_city_data/bottom_drawer';
 import GraphSettings from './components/graph_settings/graph_settings';
 import DownloadImageButton from './components/download_image/download_image_button';
 import MyGraphModal from './components/create_mygraph/mygraph_modal';
+import MyTemplateModal from './components/create_mytemplate/mytemplate_modal';
 import { checkLoggedIn } from './hooks/checkLoggedIn';
 import { useGraph } from './hooks/useGraph';
 import { useCity } from './hooks/useCity';
@@ -68,8 +69,13 @@ export default function CanvasApp() {
   const handleOpenMyGraphModal = () => setOpenMyGraphModal(true);
   const handleCloseMyGraphModal = () => setOpenMyGraphModal(false);
 
+  // マイテンプレート登録モーダルのstateとハンドラ
+  const [openMyTemplateModal, setOpenMyTemplateModal] = useState(false);
+  const handleOpenMyTemplateModal = () => setOpenMyTemplateModal(true);
+  const handleCloseMyTemplateModal = () => setOpenMyTemplateModal(false);
+
   // 下ドロワーのstateとハンドラ
-  const [openBottomDrawer, setOpenBottomDrawer] = useState(true);
+  const [openBottomDrawer, setOpenBottomDrawer] = useState(false);
   const handleOpenBottomDrawer = () => setOpenBottomDrawer(true);
   const handleCloseBottomDrawer = () => setOpenBottomDrawer(false);
 
@@ -183,6 +189,7 @@ export default function CanvasApp() {
           <Button onClick={handleOpenMyGraphModal}><MdAddChart size={35}/></Button>
           <Button onClick={handleOpenBottomDrawer}><FaEarthAsia size={30}/></Button>
           <Button onClick={handleRightDrawer} ><AiOutlineControl size={30}/></Button>
+          <Button onClick={handleOpenMyTemplateModal}>テンプレート保存</Button>
         </ButtonGroup>
       </Box>
 
@@ -201,6 +208,12 @@ export default function CanvasApp() {
           cityId={cityId}
           open={openMyGraphModal}
           handleClose={handleCloseMyGraphModal} />
+
+        {/* マイテンプレート登録モーダル */}
+        <MyTemplateModal
+          graphSetting={settingValues}
+          open={openMyTemplateModal}
+          handleClose={handleCloseMyTemplateModal} />
 
       {/* グラフ描画と右ドロワーをラップしたBox */}
       <Box sx={{ display: 'flex' }} className='bg-red-200'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :graphs, only: %i[index show create]
+    resources :templates, only: %i[index show create]
     resources :cities, only: %i[index show]
     get "check_login", to: "user_sessions#check_login"
   end


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/61

- 基本的にはマイグラフ保存機能と同じです
- レイアウトは後に調整することとして，仮でメインページ上部の操作パネルにモーダル起動ボタンを設置しています
- 設定値としてのタイトルは空欄にしてからgraph_settingsデータを保存するようにしました。

close #61 
