### PR TITLE
未ログイン状態の機能制限

### DIFF
--- a/app/controllers/api/graphs_controller.rb
+++ b/app/controllers/api/graphs_controller.rb
@@ -2,13 +2,13 @@ class Api::GraphsController < Api::BaseController
   # GET /api/graphs
   # テスト表示用
   def index
-    graphs = Graph.all
-    render json: { message: 'Hello, World!', graphs: graphs }
+    graphs = current_user.graphs.all
+    render json: { current_user: current_user, graphs: graphs }
   end
 
   # GET /api/graphs/:id
   def show
-    graph = Graph.find(params[:id])
+    graph = current_user.graphs.find(params[:id])
     render json: { graph: graph, graph_setting: graph.graph_setting }
   end
 

--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -3,12 +3,12 @@ class Api::TemplatesController < Api::BaseController
   # テスト表示用
   def index
     templates = current_user.templates
-    render json: { templates: templates }
+    render json: { current_user: current_user, templates: templates }
   end
 
   # GET /api/templates/:id
   def show
-    template = Template.find(params[:id])
+    template = current_user.templates.find(params[:id])
     render json: { template: template, graph_setting: template.graph_setting }
   end
 

--- a/app/javascript/react/canvas/components/download_image/download_image_button.jsx
+++ b/app/javascript/react/canvas/components/download_image/download_image_button.jsx
@@ -47,7 +47,7 @@ export default function DownloadImageButton({
         >
           <Box className="" sx={style}>
             <div className="container">
-              <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>出力ファイル設定</h2>
+              <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>画像ファイル出力</h2>
               <div style={{ display: 'grid', gridTemplateColumns: '100px 100px', gap: '10px' }}>
                 <label htmlFor="outputWidth">縦幅</label>
                 <input 

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -7,7 +7,7 @@ import Drawer from '@mui/material/Drawer';
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
 
-import { Select, MenuItem, FormControl, InputLabel, Divider } from '@mui/material';
+import { Select, MenuItem, FormControl, InputLabel, Tooltip } from '@mui/material';
 
 import { MdAddChart } from "react-icons/md";
 import { FaEarthAsia } from "react-icons/fa6";
@@ -29,7 +29,6 @@ import { reshapeData } from './components/graph/reshapeData';
 import { getTemplateList } from './hooks/getTemplateList';
 
 import { updateByTemplate } from './components/fetch_template/updateByTemplate';
-import { set } from 'react-hook-form';
 
 
 const drawerWidth = 300;
@@ -186,12 +185,23 @@ export default function CanvasApp() {
           aria-label="Basic button group"
           sx={{ marginBottom: 5 }}
           >
-          <Button 
-            // sx={{ background: "#5a7c65" }} 
-            onClick={handleOpenDLImageModal}><AiOutlinePicture size={35}/></Button>
-          <Button onClick={handleOpenMyGraphModal}><MdAddChart size={35}/></Button>
-          <Button onClick={handleOpenBottomDrawer}><FaEarthAsia size={30}/></Button>
-          <Button onClick={handleRightDrawer} ><AiOutlineControl size={30}/></Button>
+          <Tooltip title="画像ファイル出力">
+            <Button 
+              // sx={{ background: "#5a7c65" }} 
+              onClick={handleOpenDLImageModal}><AiOutlinePicture size={35}/>
+            </Button>
+          </Tooltip>
+          <Tooltip title={loggedIn ? "マイグラフ保存" : "マイグラフ機能はログイン後に利用できます" }>
+            <span>               {/* disabled中のボタンにもTooltipをつけるには，spanタグで囲む必要がある */}
+            <Button onClick={handleOpenMyGraphModal} disabled={!loggedIn} ><MdAddChart size={35}/></Button>
+            </span>
+          </Tooltip>
+          <Tooltip title="都市データ選択">
+            <Button onClick={handleOpenBottomDrawer}><FaEarthAsia size={30}/></Button>
+          </Tooltip>
+          <Tooltip title="グラフ設定を開く">
+            <Button onClick={handleRightDrawer} ><AiOutlineControl size={30}/></Button>
+          </Tooltip>
         </ButtonGroup>
       </Box>
 

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -183,7 +183,7 @@ export default function CanvasApp() {
         <ButtonGroup 
           variant="contained"
           aria-label="Basic button group"
-          sx={{ marginBottom: 5 }}
+          sx={{ marginBottom: 8 }}
           >
           <Tooltip title="画像ファイル出力">
             <Button 
@@ -268,19 +268,25 @@ export default function CanvasApp() {
         > 
 
           <Box backgroundColor="" marginBottom={2} width='100%'>
-            <Button 
-              onClick={() => updateByTemplate(selectedTemplate, settingValues.title, setSettingValues)}
-              variant='contained'
-              sx={{ 
-                height: 30,
-                width: '100%',
-                marginBottom: 1,
-              }}
-            >
-              選択中のテンプレートを適用
-            </Button>
+            <Tooltip title={loggedIn ? "" : "テンプレート機能はログイン後に利用できます" }>
+              <span>
+                <Button 
+                  disabled={!loggedIn}
+                  onClick={() => updateByTemplate(selectedTemplate, settingValues.title, setSettingValues)}
+                  variant='contained'
+                  sx={{ 
+                    height: 30,
+                    width: '100%',
+                    marginBottom: 1,
+                  }}
+                >
+                  選択中のテンプレートを適用
+                </Button>
+              </span>
+            </Tooltip>
             <FormControl 
               variant='filled'
+              disabled={!loggedIn}
               sx={{ height: 40, width: '100%', marginBottom: 3}}
             >
               <InputLabel>テンプレートを選択</InputLabel>
@@ -297,15 +303,20 @@ export default function CanvasApp() {
           {/* グラフ設定値入力コンポーネント */}
           <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
           {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
-          
+
           <Box backgroundColor="" marginY={2} width='100%'>
-            <Button 
-              onClick={handleOpenMyTemplateModal}
-              variant='contained'
-              sx={{ height: 30, width: '100%', marginTop: 3 }}
-            >
-              設定をマイテンプレートに保存
-            </Button>
+            <Tooltip title={loggedIn ? "" : "テンプレート機能はログイン後に利用できます" }>
+              <span>
+                <Button
+                  disabled={!loggedIn}
+                  onClick={handleOpenMyTemplateModal}
+                  variant='contained'
+                  sx={{ height: 30, width: '100%', marginTop: 2 }}
+                >
+                  設定をマイテンプレートに保存
+                </Button>
+              </span>
+            </Tooltip>
           </Box>
         </Drawer>
       </Box>


### PR DESCRIPTION
次のissueの項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/113

- React側で持たせているログイン状態 loggedInを使って，Tooltipコンポーネントの描画や，ボタンのdisabledオプションを条件分岐させました
- コントローラー側で，ログインの必要なページ遷移にはrequire_loginがついていることを確認しました（都市一覧ページは未だ実装途中のため後日）
- apiコントローラーでも，マイグラフとマイテンプレートはデータ提供の起点がcurrent_userとなるように実装しました。

![image](https://github.com/g-sawada/u-on-zu/assets/118000212/3c7e6c5f-6e45-4e13-aeae-f66ff252b3de)


close #113 