### PR TITLE
東京データのマイグラフでローディングが解除されない問題に対処

### DIFF
--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -142,7 +142,13 @@ export default function CanvasApp() {
   useEffect(() => {
     if (graph) {
       console.log('graphのcity_id:', graph.graph.city_id)
-      setCityId(graph.graph.city_id);   //マイグラフに紐づくcity_idでstateを更新 → 都市データのfetchが走る
+
+      if (graph.graph.city_id !== cityId) {  //マイグラフのcity_idが現在のcityIdと異なる場合は，cityIdを更新
+        setCityId(graph.graph.city_id);   //マイグラフに紐づくcity_idでstateを更新 → 都市データのfetchが走る
+      } else {
+        setCityLoading(false);  //cityIdが更新されない場合は，cityLoadingをfalseにしてメインコンポーネントのレンダリングを再開
+      }
+
       setSettingValues(graph.graph_setting.settings);  //マイグラフの設定値をstateにセット
     }
   }, [graph]);

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -12,11 +12,8 @@
         li
           = link_to "ログイン", login_path
 
-    .btn.btn-ghost.text-xl
-      = link_to "U-ON-ZU!", root_path
+    = link_to "U-ON-ZU!", root_path, class: "btn btn-ghost text-xl"
 
   .flex-none
-    .btn.btn-ghost.text-xl
-      = link_to "新規ユーザー登録", new_user_path
-    .btn.btn-ghost.text-xl
-      = link_to "ログイン", login_path
+    = link_to "新規ユーザー登録", new_user_path, class: "btn btn-ghost text-xl"
+    = link_to "ログイン", login_path, class: "btn btn-ghost text-xl"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -15,8 +15,8 @@
           = link_to "マイページ", mypage_path
         li
           = link_to "ログアウト", logout_path, data: { turbo_method: :delete }
-    .btn.btn-ghost.text-xl
-      = link_to "U-ON-ZU!", root_path
+
+    = link_to "U-ON-ZU!", root_path, class: "btn btn-ghost text-xl"
 
   .flex-none
     / .btn.btn-ghost.text-xl

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -5,11 +5,8 @@
     = image_tag 'toppage_uonzu.png', class: "bg-cover bg-center bg-no-repeat h-[300px] w-[300px] mx-auto mb-6 shadow-2xl rounded-md"
     div.mx-auto
       p.text-2xl.mx-auto 雨温図を自由に簡単に作成できます
-      button.btn.btn-primary.my-6 
-        = link_to "さっそく使ってみる", canvas_path
+      = link_to "さっそく使ってみる", canvas_path, class: "btn btn-primary my-6"
 
       .flex.justify-center.space-x-8
-        button.btn.btn-outline 
-          = link_to "新規ユーザー登録", new_user_path
-        button.btn.btn-outline 
-          = link_to "ログイン", login_path
+        = link_to "新規ユーザー登録", new_user_path, class: "btn btn-outline"
+        = link_to "ログイン", login_path, class: "btn btn-outline"


### PR DESCRIPTION
都市データが東京のマイグラフで「編集」ボタンを押し，canvas画面に遷移したとき，ローディングが解除されない問題を解決しました。
- 原因は，cityIdの初期値1から更新がないにもかかわらず，graphのデータフェッチ後にsetCityLoading(true)が実行されるためです。
- index.jsxのgraphフェッチ後のuseEffect処理で，graphデータに紐づくgraph.graph.city_idと現在のcityIdステート値が同じかどうかを確かめ，異なればcityIdを更新，同じであればcityLoadingを解除する分岐処理に変更しました


ついでに，トップページやヘッダーのボタンリンクの記述が誤っており，テキスト部分にのみリンクが適用されていた問題を修正しました。