### PR TITLE
マイグラフ・マイテンプレート削除機能の実装

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -8,6 +8,12 @@ class GraphsController < ApplicationController
   def show
   end
 
+  def destroy
+    graph = current_user.graphs.find(params[:id])
+    graph.destroy!
+    redirect_to graphs_path, info: "マイグラフ「#{graph.title}」を削除しました", status: :see_other
+  end
+
   private
 
   # 追々，Concernを使って共通化する

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -8,6 +8,12 @@ class TemplatesController < ApplicationController
   def show
   end
 
+  def destroy
+    template = current_user.templates.find(params[:id])
+    template.destroy!
+    redirect_to templates_path, info: "マイテンプレート「#{template.title}」を削除しました", status: :see_other
+  end
+
   private
 
   # 追々，Concernを使って共通化する

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -2,7 +2,7 @@
   h1.text-3xl.font-bold 
     | #{current_user.username} さんのマイグラフ
   .text-sm 
-  | （詳細画面・削除機能は開発中です。「編集」でグラフ作成ページに遷移します。マイグラフの上書き保存はできません。）
+  | （詳細画面は開発中です。「編集」でグラフ作成ページに遷移します。マイグラフの上書き保存はできません。）
 
   .shadow-lg.rounded-lg.overflow-x-auto.mx-4.my-5
     table.w-full.text-md.text-left.text-base 
@@ -36,5 +36,5 @@
             td.px-2.py-4 
               = link_to '編集', canvas_path(graph: graph.id), class: 'text-blue-500'
             td.px-2.py-4 
-              = link_to '削除', "#", class: 'text-red-500'
+              = link_to '削除', graph_path(graph), data: { turbo_method: :delete, turbo_confirm: '削除してもよろしいですか？' }, class: 'text-red-500'
 

--- a/app/views/templates/index.html.slim
+++ b/app/views/templates/index.html.slim
@@ -2,7 +2,7 @@
   h1.text-3xl.font-bold 
     | #{current_user.username} さんのマイテンプレート
   .text-sm 
-    | （テンプレートの管理機能は現在開発中です）
+    | （テンプレートの編集機能は現在開発中です...）
 
   .shadow-lg.rounded-lg.overflow-x-auto.mx-4.my-5
     table.w-full.text-md.text-left.text-base 
@@ -24,4 +24,4 @@
             td.px-2.py-4 
               = link_to '編集', "#", class: 'text-blue-500'
             td.px-2.py-4 
-              = link_to '削除', "#", class: 'text-red-500'
+              = link_to '削除', template_path(template), data: { turbo_method: :delete, turbo_confirm: '削除してもよろしいですか？' }, class: 'text-red-500'


### PR DESCRIPTION
次のissueの項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/63

https://github.com/g-sawada/u-on-zu/issues/60


- いずれも一覧画面の削除ボタンのみ実装しています
- コンソールから，紐づくgraph_settingの同時削除も確認しました（dependent: :destroy）
https://i.gyazo.com/6825df8eaf4bd43dea2aab62d5434bbb.gif


close #63 
close #60 