### PR TITLE
ログイン後の遷移先をcanvasに変更

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -10,7 +10,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to root_path, success: 'ログインしました'
+      redirect_back_or_to canvas_path, success: 'ログインしました'
     else
       flash.now[:error] = 'ログインに失敗しました'
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
次のissue項目を完了
https://github.com/g-sawada/u-on-zu/issues/149

- ログイン後の redirect_back_or_to の遷移先をcanvas_pathに変更

close #149 