### PR TITLE
マイグラフ・マイテンプレート保存完了ダイアログの表示

### DIFF
--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -3,6 +3,8 @@ import { useForm } from "react-hook-form";
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
 
+import ConfirmationDialog from "../shared/confirmation_dialog";
+
 const style = {
   position: 'absolute',
   top: '50%',
@@ -26,7 +28,17 @@ export default function MyGraphModal({ graphSetting, cityId, open, handleClose }
 
   const [serverError, setServerError] = useState(''); //サーバーエラーのステート
 
-  //⭐ フォームの送信処理
+  //確認ダイアログのstateとハンドラ
+  const [openDialog, setOpenDialog] = useState(false);
+  const handleOpenDialog = () => {
+    setOpenDialog(true);
+  };
+  const handleCloseDialog = () => {
+    setOpenDialog(false);
+  }
+
+  
+  //フォームの送信処理
   const onSubmit = async (data) => {
     try {
       const response = await createGraph(  //バックへPOSTリクエスト, 後ろで定義
@@ -39,6 +51,7 @@ export default function MyGraphModal({ graphSetting, cityId, open, handleClose }
         console.log('responseData : ', responseData);
         reset();       //フォームのリセット
         handleClose();  //モーダルを閉じる
+        handleOpenDialog(); //確認ダイアログを表示
       } else {
         // setServerError('サーバーエラーが発生しました。');
         console.log('サーバーエラーが発生しました。');
@@ -67,44 +80,52 @@ export default function MyGraphModal({ graphSetting, cityId, open, handleClose }
     return response;
   }
 
-  return (
-    <Modal
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="modal-modal-title"
-      aria-describedby="modal-modal-description"
-    >
-      <Box className="" sx={style}>
-        <div className="container">
-          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
-            <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイグラフ保存</h2>
-            {/* エラーメッセージ表示部分 */}
-            {/* <ErrorMessage message={serverError} />
-            <ErrorMessage message={errors.title?.message || ''} /> */}
-            
-            {/* Title */}
-            <label htmlFor="title" className="mb-2 text-lg">
-              タイトル
-            </label>
-            <input
-              {...register('title', { required: 'Titleを入力して下さい。' })}
-              className="input input-bordered mb-5"
-            />
 
-            {/* Note */}
-            <label htmlFor="note" className="mb-2 text-lg">
-              メモ
-            </label>
-            <textarea
-              {...register('note')}
-              className="textarea textarea-bordered mb-5"
-            />
-            <button type="submit" className="btn mt-2">
-              マイグラフ保存
-            </button>
-          </form>
-        </div>
-      </Box>
-    </Modal>
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box className="" sx={style}>
+          <div className="container">
+            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
+              <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイグラフ保存</h2>
+              {/* エラーメッセージ表示部分 */}
+              {/* <ErrorMessage message={serverError} />
+              <ErrorMessage message={errors.title?.message || ''} /> */}
+              
+              {/* Title */}
+              <label htmlFor="title" className="mb-2 text-lg">
+                タイトル
+              </label>
+              <input
+                {...register('title', { required: 'Titleを入力して下さい。' })}
+                className="input input-bordered mb-5"
+              />
+
+              {/* Note */}
+              <label htmlFor="note" className="mb-2 text-lg">
+                メモ
+              </label>
+              <textarea
+                {...register('note')}
+                className="textarea textarea-bordered mb-5"
+              />
+              <button type="submit" className="btn mt-2">
+                マイグラフ保存
+              </button>
+            </form>
+          </div>
+        </Box>
+      </Modal>
+
+      <ConfirmationDialog open={openDialog} handleClose={handleCloseDialog}>
+        マイグラフの保存が完了しました!
+      </ConfirmationDialog>
+    </>
   )
 }

--- a/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
@@ -3,6 +3,8 @@ import { useForm } from "react-hook-form";
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
 
+import ConfirmationDialog from "../shared/confirmation_dialog";
+
 const style = {
   position: 'absolute',
   top: '50%',
@@ -25,7 +27,16 @@ export default function MyTemplateModal({ graphSetting, open, handleClose }) {
 
   const [serverError, setServerError] = useState(''); //サーバーエラーのステート
 
-  //⭐ フォームの送信処理
+  //確認ダイアログのstateとハンドラ
+  const [openDialog, setOpenDialog] = useState(false);
+  const handleOpenDialog = () => {
+    setOpenDialog(true);
+  };
+  const handleCloseDialog = () => {
+    setOpenDialog(false);
+  }
+
+  //フォームの送信処理
   const onSubmit = async (data) => {
     try {
       const response = await createTemplate(  //バックへPOSTリクエスト, 後ろで定義
@@ -37,6 +48,7 @@ export default function MyTemplateModal({ graphSetting, open, handleClose }) {
         console.log('responseData : ', responseData);
         reset();       //フォームのリセット
         handleClose();  //モーダルを閉じる
+        handleOpenDialog(); //確認ダイアログを表示
       } else {
         // setServerError('サーバーエラーが発生しました。');
         console.log('サーバーエラーが発生しました。');
@@ -66,35 +78,41 @@ export default function MyTemplateModal({ graphSetting, open, handleClose }) {
   }
 
   return (
-    <Modal
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="modal-modal-title"
-      aria-describedby="modal-modal-description"
-    >
-      <Box className="" sx={style}>
-        <div className="container">
-          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
-            <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイテンプレート保存</h2>
-            {/* エラーメッセージ表示部分 */}
-            {/* <ErrorMessage message={serverError} />
-            <ErrorMessage message={errors.title?.message || ''} /> */}
-            
-            {/* Title */}
-            <label htmlFor="title" className="mb-2 text-lg">
-              テンプレートタイトル
-            </label>
-            <input
-              {...register('title', { required: 'Titleを入力して下さい。' })}
-              className="input input-bordered mb-5"
-            />
-            <button type="submit" className="btn mt-2">
-              マイテンプレート保存
-            </button>
-          </form>
-        </div>
-      </Box>
-    </Modal>
+    <>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box className="" sx={style}>
+          <div className="container">
+            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
+              <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイテンプレート保存</h2>
+              {/* エラーメッセージ表示部分 */}
+              {/* <ErrorMessage message={serverError} />
+              <ErrorMessage message={errors.title?.message || ''} /> */}
+              
+              {/* Title */}
+              <label htmlFor="title" className="mb-2 text-lg">
+                テンプレートタイトル
+              </label>
+              <input
+                {...register('title', { required: 'Titleを入力して下さい。' })}
+                className="input input-bordered mb-5"
+              />
+              <button type="submit" className="btn mt-2">
+                マイテンプレート保存
+              </button>
+            </form>
+          </div>
+        </Box>
+      </Modal>
+
+      <ConfirmationDialog open={openDialog} handleClose={handleCloseDialog}>
+        マイテンプレートの保存が完了しました!
+      </ConfirmationDialog>
+    </>
   )
 }
 

--- a/app/javascript/react/canvas/components/shared/confirmation_dialog.jsx
+++ b/app/javascript/react/canvas/components/shared/confirmation_dialog.jsx
@@ -1,4 +1,4 @@
-import React, { Children, useState } from "react";
+import React from "react";
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';

--- a/app/javascript/react/canvas/components/shared/confirmation_dialog.jsx
+++ b/app/javascript/react/canvas/components/shared/confirmation_dialog.jsx
@@ -1,0 +1,29 @@
+import React, { Children, useState } from "react";
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogTitle from '@mui/material/DialogTitle';
+
+export default function ConfirmationDialog({open, handleClose, children}) {
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          <div className="text-lg m-4">
+            {children}
+          </div>
+        </DialogTitle>
+        <DialogActions>
+          <Button onClick={handleClose} autoFocus>
+            OK
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/152

- canvas/components内に，共通化できるコンポーネントを格納するsharedディレクトリを作成しました
- sharedにconfirmation_dialog.jsxを作成し，ConfirmationDialogコンポーネントを定義しました
- ConfirmationDialogでは，親コンポーネント側でダイアログの開閉stateとハンドラが宣言されており，propでstateとcloseハンドラが引き渡されることを想定しています。
- また，childrenを設定しており，ダイアログのメッセージ部分だけを任意の値に設定できるようにしています。それ以外は全て共通化させています。
- mygraph_modal.jsxとmytemplate_modal.jsxでConfirmationDialogを呼び出し，responce.ok後の処理の最後にダイアログのopenハンドラを実行するようにしました


https://i.gyazo.com/8100b28cc68a5ef9e91c3591f7326823.gif

close #152 

