### PR TITLE
全ページでgonの設定を行うようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :set_gon    # 全てのページで最初にgonに環境変数をセットする
 
   add_flash_types :success, :info, :warning, :error
 
+  def set_gon
+    gon.google_maps_api_key = ENV['GOOGLE_MAPS_API_KEY']
+  end
 end

--- a/app/controllers/canvas_controller.rb
+++ b/app/controllers/canvas_controller.rb
@@ -1,5 +1,4 @@
 class CanvasController < ApplicationController
   def index
-    gon.google_maps_api_key = ENV['GOOGLE_MAPS_API_KEY']
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,7 +3,6 @@ class StaticPagesController < ApplicationController
   end
 
   def develop
-    gon.google_maps_api_key = ENV['GOOGLE_MAPS_API_KEY']
   end
 
   def contact


### PR DESCRIPTION
本番環境で，トップページからメイン画面にページ遷移した際，gonへの環境変数の読み込みが行われなかったのは，canvasのindexアクションでのみ，実行されていたからと考え，applicationコントローラーのbefore_actionで全コントローラーに同様の処理を行うこととした

この対処は一時的・実験的なものである。

