### PR TITLE
下ドロワーの挙動改善

### DIFF
--- a/app/javascript/react/canvas/components/fetch_city_data/GoogleMapComponent.jsx
+++ b/app/javascript/react/canvas/components/fetch_city_data/GoogleMapComponent.jsx
@@ -28,7 +28,7 @@ export default function GoogleMapComponent({setCityId}) {
     <APIProvider apiKey={googleMapsApiKey}>
       <Map
         mapId={'160dcc337dc1872'}
-        style={{width: '50%', height: '30vh', margin: 'auto'}}
+        style={{width: '100%', height: '40vh', margin: 'auto'}}
         defaultCenter={{lat: 36.6513, lng: 138.1810}}
         defaultZoom={4.6}
         gestureHandling={'greedy'}

--- a/app/javascript/react/canvas/components/fetch_city_data/GoogleMapComponent.jsx
+++ b/app/javascript/react/canvas/components/fetch_city_data/GoogleMapComponent.jsx
@@ -28,7 +28,7 @@ export default function GoogleMapComponent({setCityId}) {
     <APIProvider apiKey={googleMapsApiKey}>
       <Map
         mapId={'160dcc337dc1872'}
-        style={{width: '100%', height: '40vh', margin: 'auto'}}
+        style={{width: '100%', height: '35vh', margin: 'auto'}}
         defaultCenter={{lat: 36.6513, lng: 138.1810}}
         defaultZoom={4.6}
         gestureHandling={'greedy'}

--- a/app/javascript/react/canvas/components/fetch_city_data/bottom_drawer.jsx
+++ b/app/javascript/react/canvas/components/fetch_city_data/bottom_drawer.jsx
@@ -7,25 +7,32 @@ import ClickAwayListener from '@mui/material/ClickAwayListener';
 import GoogleMapComponent from './GoogleMapComponent';
 
 export default function BottomDrawer({open, handleClose, bottomDrawerButtonRef, setCityId}) {
-  const [selectedCity, setSelectedCity] = useState(null);
-  
+  // ドロワーの状態，ドロワー閉ハンドラ，下ドロワー起動ボタンのref，setCityId関数
+
+  // ClickAwayListenerで指定する，ドロワー外をクリックした時の処理
   const handleClickAway = (event) => {
+    //index.jsxから引き受けたRefを使って，起動ボタンをクリックした時はhandleCloseを実行しないようにする
     if (bottomDrawerButtonRef.current && bottomDrawerButtonRef.current.contains(event.target)) {
       return;
     }
     handleClose();
   }
   
+  // セレクトボックスで選択中の都市情報を保持するステート
+  const [selectedCity, setSelectedCity] = useState(null);
+  
+  // 都市名セレクトボックスの変更ハンドラ
   const handleChange = (e, value) => {
     setSelectedCity(value);
   }
+  // 都市名選択の反映実行ボタンクリックのハンドラ
   const handleButtonClick = () => {
     if (selectedCity) {
-      console.log('selectedCity.name:', selectedCity.name, 'selectedCity.id:', selectedCity.id);
       setCityId(selectedCity.id);   //index.jsxから引き受けたsetCityId関数を実行し，選択した都市IDを更新
     }
   }
 
+  // モックデータ
   const cityIdMapping = [
     { id: 1, name: '東京', position: { lat: 35.6917, lng: 139.75, alt: 25.2 }},
     { id: 2, name: '大阪', position: { lat: 34.6817, lng: 135.5183, alt: 23.0 }},

--- a/app/javascript/react/canvas/components/fetch_city_data/bottom_drawer.jsx
+++ b/app/javascript/react/canvas/components/fetch_city_data/bottom_drawer.jsx
@@ -1,14 +1,21 @@
 import React, { useState } from 'react';
 import Box from '@mui/material/Box';
-import SwipeableDrawer from '@mui/material/SwipeableDrawer';
-import TextField from '@mui/material/TextField';
-import Autocomplete from '@mui/material/Autocomplete';
-import Button from '@mui/material/Button';
+// import SwipeableDrawer from '@mui/material/SwipeableDrawer';
+import Drawer from '@mui/material/Drawer';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 
 import GoogleMapComponent from './GoogleMapComponent';
 
-export default function BottomDrawer({open, handleClose, setCityId}) {
+export default function BottomDrawer({open, handleClose, bottomDrawerButtonRef, setCityId}) {
   const [selectedCity, setSelectedCity] = useState(null);
+  
+  const handleClickAway = (event) => {
+    if (bottomDrawerButtonRef.current && bottomDrawerButtonRef.current.contains(event.target)) {
+      return;
+    }
+    handleClose();
+  }
+  
   const handleChange = (e, value) => {
     setSelectedCity(value);
   }
@@ -27,50 +34,52 @@ export default function BottomDrawer({open, handleClose, setCityId}) {
     ]
 
   return (
-    <SwipeableDrawer
-      anchor='bottom'
-      open={open}
-      onClose={handleClose}
-    >
-      {/* カラムから呼び出し */}
-      {/* <Box 
-        sx={{ 
-          width: '100%',
-          // height: '200px',
-          margin: '30px',
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'center',
-          alignItems: 'flex-start',
-        }}
-        role="presentation">
-        <Autocomplete
-        onChange={handleChange}
-        disablePortal
-        options={cityIdMapping}
-        getOptionLabel={(option) => option.name}
-        sx={{ width: 300, height: 50}}
-        renderInput={(params) => <TextField {...params} label="都市を選択" />}
-        />
-        <Button 
-          onClick={handleButtonClick}
-          variant='contained'
-          size='large'
-          sx={{ height: 50, marginLeft: '20px' }}
-        >
-          グラフに反映
-        </Button>
-      </Box> */}
-      
-      {/* GoogleMapから呼び出し */}
-      <Box 
-        sx={{
-          margin: '10px'
-        }} 
+    <ClickAwayListener onClickAway={handleClickAway}>
+      <Drawer
+        variant='persistent'
+        anchor='bottom'
+        open={open}
+        // onClose={handleClose}
       >
-        <GoogleMapComponent setCityId={setCityId}/>
-      </Box>
-
-    </SwipeableDrawer>
+        {/* カラムから呼び出し */}
+        {/* <Box 
+          sx={{ 
+            width: '100%',
+            // height: '200px',
+            margin: '30px',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'flex-start',
+          }}
+          role="presentation">
+          <Autocomplete
+          onChange={handleChange}
+          disablePortal
+          options={cityIdMapping}
+          getOptionLabel={(option) => option.name}
+          sx={{ width: 300, height: 50}}
+          renderInput={(params) => <TextField {...params} label="都市を選択" />}
+          />
+          <Button 
+            onClick={handleButtonClick}
+            variant='contained'
+            size='large'
+            sx={{ height: 50, marginLeft: '20px' }}
+          >
+            グラフに反映
+          </Button>
+        </Box> */}
+        
+        {/* GoogleMapから呼び出し */}
+        <Box 
+          sx={{
+            marginTop: '5px'
+          }} 
+        >
+          <GoogleMapComponent setCityId={setCityId}/>
+        </Box>
+      </Drawer>
+    </ClickAwayListener>
   );
 }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 import { styled } from '@mui/material/styles';
 // import { makeStyles } from "@material-ui/core/styles";
@@ -68,7 +68,10 @@ export default function CanvasApp() {
   const useModalDrawerState = () => {
     const [isOpen, setIsOpen] = useState(false);
     const handleOpen = () => setIsOpen(true);
-    const handleClose = () => setIsOpen(false);
+    const handleClose = () => {
+      console.log('test')
+      setIsOpen(false);
+    }
     return [ isOpen, handleOpen, handleClose ];
   }
 
@@ -80,6 +83,9 @@ export default function CanvasApp() {
   const [openMyTemplateModal, handleOpenMyTemplateModal, handleCloseMyTemplateModal] = useModalDrawerState();
   // 下ドロワーのstateとハンドラ
   const [openBottomDrawer, handleOpenBottomDrawer, handleCloseBottomDrawer] = useModalDrawerState();
+
+  // 下ドロワーの起動ボタンを，ClickAwayListenerの対象外にするためのref
+  const bottomDrawerButtonRef = useRef(null);
 
 
   //都市IDをstateで管理。初期値は1（東京）
@@ -203,7 +209,8 @@ export default function CanvasApp() {
             </span>
           </Tooltip>
           <Tooltip title="都市データ選択">
-            <Button onClick={handleOpenBottomDrawer}><FaEarthAsia size={30}/></Button>
+                    {/* useRefでこのボタンを特定し，BottomDrawer内でClickAwayListnerの処理の対象外とする */}
+            <Button ref={bottomDrawerButtonRef} onClick={handleOpenBottomDrawer}><FaEarthAsia size={30}/></Button>
           </Tooltip>
           <Tooltip title="グラフ設定を開く">
             <Button onClick={handleRightDrawer} ><AiOutlineControl size={30}/></Button>
@@ -328,7 +335,11 @@ export default function CanvasApp() {
       </Box>
 
       {/* 下ドロワー */}
-      <BottomDrawer open={openBottomDrawer} handleClose={handleCloseBottomDrawer} setCityId={setCityId}/>
+      <BottomDrawer 
+        open={openBottomDrawer}
+        handleClose={handleCloseBottomDrawer}
+        bottomDrawerButtonRef={bottomDrawerButtonRef}
+        setCityId={setCityId}/>
       <div>ここにImage</div>
       <img alt="" id="output" />
     </>


### PR DESCRIPTION
- 下ドロワーのモードを persistentにし，起動中に背景を暗転させず，重なった下の要素のスクロールを可能にした
- ClickAwayListenerコンポーネントを導入し，useRefと組み合わせることで，下ドロワー以外の要素のクリック（下ドロワー起動ボタンを除く）で，下ドロワーのhandleCloseを起動するようにした。
- 下ドロワー起動中にグラフが重なって見えなくなってしまっていた問題が，大分解消されたように思われる


https://i.gyazo.com/6c49afd6702993e6c1fd678831b79b22.gif