### PR TITLE
マイグラフ・マイテンプレートの送信フォームにuseFromのバリデーション機能を実装

### DIFF
--- a/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mygraph/mygraph_modal.jsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
 
+import ErrorMessage from "../shared/error_message";
 import ConfirmationDialog from "../shared/confirmation_dialog";
 
 const style = {
@@ -23,7 +24,7 @@ export default function MyGraphModal({ graphSetting, cityId, open, handleClose }
     register,
     handleSubmit,
     reset,
-    // formState: { errors },
+    formState: { errors },
   } = useForm();
 
   const [serverError, setServerError] = useState(''); //サーバーエラーのステート
@@ -54,8 +55,8 @@ export default function MyGraphModal({ graphSetting, cityId, open, handleClose }
         handleOpenDialog(); //確認ダイアログを表示
       } else {
         const errorData = await response.json();
-        // setServerError('サーバーエラーが発生しました。');
-        console.log('サーバーエラーが発生しました。', errorData.error);
+        setServerError('サーバーからの応答がエラーです。');
+        console.error('server response (error): ', errorData.error);
       }
     } catch (error) {
       setServerError('リクエスト中にエラーが発生しました。');
@@ -95,16 +96,20 @@ export default function MyGraphModal({ graphSetting, cityId, open, handleClose }
           <div className="container">
             <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
               <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイグラフ保存</h2>
+              
               {/* エラーメッセージ表示部分 */}
-              {/* <ErrorMessage message={serverError} />
-              <ErrorMessage message={errors.title?.message || ''} /> */}
+              <ErrorMessage message={serverError} />
+              <ErrorMessage message={errors.title?.message || ''} />
+              <ErrorMessage message={errors.note?.message || ''} />
               
               {/* Title */}
               <label htmlFor="title" className="mb-2 text-lg">
                 タイトル
               </label>
               <input
-                {...register('title', { required: 'Titleを入力して下さい。' })}
+                {...register('title', {
+                              required: 'タイトルを入力して下さい。',
+                              maxLength: {value: 255, message: 'タイトルは255文字以内で入力して下さい。'}})}
                 className="input input-bordered mb-5"
               />
 
@@ -113,7 +118,8 @@ export default function MyGraphModal({ graphSetting, cityId, open, handleClose }
                 メモ
               </label>
               <textarea
-                {...register('note')}
+                {...register('note', {
+                              maxLength: {value: 65535, message: 'メモは65535文字以内で入力して下さい。'}})}
                 className="textarea textarea-bordered mb-5"
               />
               <button type="submit" className="btn mt-2">

--- a/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
+++ b/app/javascript/react/canvas/components/create_mytemplate/mytemplate_modal.jsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
 
+import ErrorMessage from "../shared/error_message";
 import ConfirmationDialog from "../shared/confirmation_dialog";
 
 const style = {
@@ -22,7 +23,7 @@ export default function MyTemplateModal({ graphSetting, open, handleClose }) {
     register,
     handleSubmit,
     reset,
-    // formState: { errors },
+    formState: { errors },
   } = useForm();
 
   const [serverError, setServerError] = useState(''); //サーバーエラーのステート
@@ -51,8 +52,8 @@ export default function MyTemplateModal({ graphSetting, open, handleClose }) {
         handleOpenDialog(); //確認ダイアログを表示
       } else {
         const errorData = await response.json();
-        // setServerError('サーバーエラーが発生しました。');
-        console.log('サーバーエラーが発生しました。', errorData.error);
+        setServerError('サーバーからの応答がエラーです。');
+        console.error('server response (error): ', errorData.error);
       }
     } catch (error) {
       setServerError('リクエスト中にエラーが発生しました。');
@@ -90,16 +91,19 @@ export default function MyTemplateModal({ graphSetting, open, handleClose }) {
           <div className="container">
             <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
               <h2 className="text-2xl font-bold" style={{marginBottom: '40px'}}>マイテンプレート保存</h2>
+
               {/* エラーメッセージ表示部分 */}
-              {/* <ErrorMessage message={serverError} />
-              <ErrorMessage message={errors.title?.message || ''} /> */}
+              <ErrorMessage message={serverError} />
+              <ErrorMessage message={errors.title?.message || ''} />
               
               {/* Title */}
               <label htmlFor="title" className="mb-2 text-lg">
                 テンプレートタイトル
               </label>
               <input
-                {...register('title', { required: 'Titleを入力して下さい。' })}
+                {...register('title', {
+                              // required: 'タイトルを入力して下さい。',
+                              maxLength: {value: 255, message: 'タイトルは255文字以内で入力して下さい。'}})}                
                 className="input input-bordered mb-5"
               />
               <button type="submit" className="btn mt-2">

--- a/app/javascript/react/canvas/components/shared/error_message.jsx
+++ b/app/javascript/react/canvas/components/shared/error_message.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function ErrorMessage({ message }) {
+  if (!message) return null
+  
+  return <p className="text-red-500">{message}</p>
+}


### PR DESCRIPTION
次のissueの項目を完了しました

https://github.com/g-sawada/u-on-zu/issues/154


- React Hook Fromのバリデーション機能を使って，マイグラフ・マイテンプレートのタイトルに，サーバー側と同様のバリデーションを実装しました。

close #154 