### PR TITLE
本番環境のメーラー設定

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,6 +4,9 @@ class UserMailer < ApplicationMailer
   def reset_password_email(user)
     @user = User.find(user.id)
     @url = edit_password_reset_url(@user.reset_password_token)
-    mail(to: user.email, subject: 'U-ON-ZU! パスワード再設定のお手続き')
+    mail(
+      from: 'U-ON-ZU! お知らせメール <info@u-on-zu.com>'
+      to: user.email,
+      subject: 'パスワード再設定のお手続き')
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,27 +37,14 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # 追記： 開発環境のメーラーをletter_opener_webに指定
   config.action_mailer.delivery_method = :letter_opener_web
-  # 追記: メーラーのURLを，gem configに設定したdefault_url_optionsから取得
+  # 追記: メーラーのホストを，gem configに設定したdefault_url_optionsから取得
   config.action_mailer.default_url_options = Settings.default_url_options.to_h
-
-  ######ここから本番環境のテスト実装#######
-  # config.action_mailer.delivery_method = :smtp
-
-  # config.action_mailer.smtp_settings = {
-  #   port: 587,
-  #   address:"smtp.gmail.com",
-  #   domain: 'gmail.com', #Gmailを使う場合
-  #   user_name: ENV['GMAIL_ADDRESS'], #Gmailアカウントのメールアドレス
-  #   password: ENV['GMAIL_PASSWORD'], #Gmailで設定したアプリパスワード
-  #   authentication: :plain,
-  #   enable_starttls_auto: true
-  # }
 
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,20 @@ Rails.application.configure do
   # 追記: メーラーのURLを，gem configに設定したdefault_url_optionsから取得
   config.action_mailer.default_url_options = Settings.default_url_options.to_h
 
+  ######ここから本番環境のテスト実装#######
+  # config.action_mailer.delivery_method = :smtp
+
+  # config.action_mailer.smtp_settings = {
+  #   port: 587,
+  #   address:"smtp.gmail.com",
+  #   domain: 'gmail.com', #Gmailを使う場合
+  #   user_name: ENV['GMAIL_ADDRESS'], #Gmailアカウントのメールアドレス
+  #   password: ENV['GMAIL_PASSWORD'], #Gmailで設定したアプリパスワード
+  #   authentication: :plain,
+  #   enable_starttls_auto: true
+  # }
+
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,21 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  # 追記:本番環境のメーラー設定
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.default_url_options = Settings.default_url_options.to_h
+
+  config.action_mailer.smtp_settings = {
+    port: 587,
+    address:"smtp.gmail.com",
+    domain: 'gmail.com',
+    user_name: ENV['GMAIL_ADDRESS'], 
+    password: ENV['GMAIL_PASSWORD'],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,3 @@
+default_url_options:
+  host: 'u-on-zu.com'
+  protocol: 'https'


### PR DESCRIPTION
次のissue項目を進行中です。
https://github.com/g-sawada/u-on-zu/issues/182

- Cloudflareで取得した独自ドメイン u-on-zu.com にカスタムメールアドレス info@u-on-zu.comを追加し，自分のGmailの送信元に追加する設定を行いました。
- これにより， from: に指定することで，Gmailのsmtpサーバーを使用しながら，受信者にはinfo@u-on-zu.comからメールが届くようになりました
- 本番環境のメーラー設定を，production.rbで次のように行いました。
- このプルリクエストをマージして，パスワード再設定メールが想定通りに配信されるか確かめます。
- 再設定用のリンク設定は，別のプルリクエストを立てて報告します

```
  # 追記:本番環境のメーラー設定
  config.action_mailer.delivery_method = :smtp

  config.action_mailer.default_url_options = Settings.default_url_options.to_h

  config.action_mailer.smtp_settings = {
    port: 587,
    address:"smtp.gmail.com",
    domain: 'gmail.com',
    user_name: ENV['GMAIL_ADDRESS'], 
    password: ENV['GMAIL_PASSWORD'],
    authentication: :plain,
    enable_starttls_auto: true
  }
```



