### PR TITLE
Google認証機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,9 @@ class ApplicationController < ActionController::Base
   def set_gon
     gon.google_maps_api_key = ENV['GOOGLE_MAPS_API_KEY']
   end
+
+  private
+  # def check_profile
+  #   redirect_to mypage_path, warning: 'ユーザー情報を登録してください' unless current_user.profile
+  # end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :set_gon    # 全てのページで最初にgonに環境変数をセットする
+  before_action :check_profile  # ログインユーザーがプロフィールを登録しているかチェックする
 
   add_flash_types :success, :info, :warning, :error
 
@@ -8,7 +9,9 @@ class ApplicationController < ActionController::Base
   end
 
   private
-  # def check_profile
-  #   redirect_to mypage_path, warning: 'ユーザー情報を登録してください' unless current_user.profile
-  # end
+  def check_profile
+    if logged_in? && current_user.occupation.nil?
+      redirect_to edit_profile_path, info: 'ご利用の前に，ユーザー情報の登録を完了して下さい。'
+    end
+  end
 end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -13,11 +13,13 @@ class OauthsController < ApplicationController
 
     else # ユーザーが存在しない場合は新規登録に進む
       begin
-        auth = sorcery_fetch_user_hash(provider)
+        sorcery_fetch_user_hash(provider)
+        auth = @user_hash
         redirect_to root_path
       rescue
         redirect_to root_path, alert: "#{provider.titleize}アカウントでのログインに失敗しました"
       end
+    end
   end
 
   private

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -7,6 +7,7 @@ class OauthsController < ApplicationController
   # 認証ページからのリダイレクトを受け取る
   def callback
     provider = auth_params[:provider]
+    binding.pry
 
     # ログインを試みる
     if @user = login_from(provider)  # login_fromはsorceryのメソッド
@@ -27,7 +28,7 @@ class OauthsController < ApplicationController
         @user = create_from(provider)  # ユーザーを新規作成
         reset_session
         auto_login(@user)
-        redirect_to mypage_path, success: "#{provider.titleize}アカウントでログインしました。続いて，ユーザー情報を登録してください。"
+        redirect_to edit_profile_path, success: "#{provider.titleize}アカウントでログインしました。続いて，ユーザー情報を登録してください。"
       end
     end
   rescue StandardError

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,0 +1,29 @@
+class OauthsController < ApplicationController
+  # 指定されたプロバイダの認証ページにリダイレクトする(login_atはsorceryのメソッド)
+  def oauth
+    login_at(params[:provider])
+  end
+
+  # 認証ページからのリダイレクトを受け取る
+  def callback
+    provider = auth_params[:provider]
+
+    if @user = login_from(provider)  # login_fromはsorceryのメソッド
+      redirect_to canvas_path, success: "#{provider.titleize}アカウントでログインしました"
+
+    else # ユーザーが存在しない場合は新規登録に進む
+      begin
+        auth = sorcery_fetch_user_hash(provider)
+        redirect_to root_path
+      rescue
+        redirect_to root_path, alert: "#{provider.titleize}アカウントでのログインに失敗しました"
+      end
+  end
+
+  private
+
+  def auth_params
+    params.permit(:code, :provider)
+  end
+
+end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -7,7 +7,6 @@ class OauthsController < ApplicationController
   # 認証ページからのリダイレクトを受け取る
   def callback
     provider = auth_params[:provider]
-    binding.pry
 
     # ログインを試みる
     if @user = login_from(provider)  # login_fromはsorceryのメソッド

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :require_login
+  skip_before_action :check_profile, only: [:edit, :update]
 
   def show
     @user = current_user

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
     @user = current_user
 
     if @user.update(user_params)
-      redirect_to mypage_path, success: "プロフィールを更新しました"
+      redirect_to profile_path, success: "プロフィールを更新しました"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :check_profile
   def top
   end
 

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,3 @@
+class Authentication < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :username,              presence: true, length: { maximum: 30 }
   validates :email,                 presence: true, uniqueness: true, length: { maximum: 255 }
-  validates :occupation,            presence: true
+  # validates :occupation,            presence: true
 
   enum occupation: {
     student_elementary: 0, student_junior: 1, student_high: 2, student_college: 3, teacher_elementary: 4,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :username,              presence: true, length: { maximum: 30 }
   validates :email,                 presence: true, uniqueness: true, length: { maximum: 255 }
-  # validates :occupation,            presence: true
+  validates :occupation,            presence: true
 
   enum occupation: {
     student_elementary: 0, student_junior: 1, student_high: 2, student_college: 3, teacher_elementary: 4,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   validates :password,              length: { minimum: 6, maximum: 20 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password,              confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :username,              presence: true, length: { maximum: 15 }
+  validates :username,              presence: true, length: { maximum: 30 }
   validates :email,                 presence: true, uniqueness: true, length: { maximum: 255 }
   validates :occupation,            presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,11 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :authentications, dependent: :destroy
   has_many :graphs, dependent: :destroy
   has_many :templates, dependent: :destroy
+
+  accepts_nested_attributes_for :authentications
 
   validates :password,              length: { minimum: 6, maximum: 20 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password,              confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -12,16 +12,24 @@
                   li
                     = message
 
-          .my-5.space-y-3
-            = f.label :username, class: 'text-xl fond-bold'
+          .my-10.space-y-3
+            = f.label :username, class: 'text-xl font-bold'
             = f.text_field :username, class: 'w-full input input-borderd input-primary'
           
-          .my-5.space-y-3
-            = f.label :email, class: 'text-xl fond-bold'
-            = f.email_field :email, class: 'w-full input input-borderd input-primary'
+          .my-10.space-y-3
+            = f.label :email, class: 'text-xl font-bold'
+            - if @user.authentications.nil?
+              = f.email_field :email, class: 'w-full input input-borderd input-primary'
+            - else
+              .w-full.text-lg
+                = @user.email
+              .px-2.py-1.inline-flex.items-center.gap-2.border.border-gray-500.rounded-md.text-slate-700.bg-white
+                img class="w-4 h-4" src="https://www.svgrepo.com/show/475656/google-color.svg" loading="lazy" alt="google logo"
+                span.text-sm Googleアカウント利用中
 
-          .my-5.space-y-3
-            = f.label :occupation, class: 'text-xl fond-bold'
+
+          .my-10.space-y-3
+            = f.label :occupation, class: 'text-xl font-bold'
             = f.select :occupation, User.occupations.keys.map { |k| [t("enum.user.occupation.#{k}"), k] }, { prompt: "選択して下さい" }, class: 'w-full select select-bordered select-primary'
 
           .my-10.flex.justify-center

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -4,7 +4,7 @@
         | ユーザー登録情報変更
     
       .my-10
-        = form_with model: @user, url: mypage_path ,local: true do |f|
+        = form_with model: @user, url: profile_path ,local: true do |f|
           - if @user.errors.any?
             div.alert.alert-error.font-bold
               ul

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -23,7 +23,7 @@
           = t("enum.user.occupation.#{@user.occupation}")
     
     .my-10.flex.justify-center
-      = link_to '変更する', 'mypage/edit', class: 'btn btn-primary'
+      = link_to '変更する', edit_profile_path, class: 'btn btn-primary'
 
     .my-10.flex.justify-center
       = link_to 'パスワード再設定', new_password_reset_path, class: 'btn btn-primary btn-warning'

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -5,25 +5,26 @@
   
     .my-10
       .my-8.space-y-3
-        .text-lg
+        .text-lg.text-xl.font-bold
           | ユーザーネーム
-        .w-full.text-xl.font-bold
+        .w-full.text-lg
           = @user.username
       
-      .my-8.space-y-3
-        .text-lg
+      .my-10.space-y-3
+        .text-lg.text-xl.font-bold
           | メールアドレス
-        .w-full.text-xl.font-bold
+        .w-full.text-lg
           = @user.email
+        .px-2.py-1.inline-flex.items-center.gap-2.border.border-gray-500.rounded-md.text-slate-700.bg-white
+          img class="w-4 h-4" src="https://www.svgrepo.com/show/475656/google-color.svg" loading="lazy" alt="google logo"
+          span.text-sm Googleアカウント利用中
 
-      .my-8.space-y-3
-        .text-lg
+      .my-10.space-y-3
+        .text-lg.text-xl.font-bold
           | 職業・学年
-        .w-full.text-xl.font-bold
+        .w-full.text-lg
           = t("enum.user.occupation.#{@user.occupation}")
     
-    .my-10.flex.justify-center
+    .my-10.flex.justify-center.gap-14
       = link_to '変更する', edit_profile_path, class: 'btn btn-primary'
-
-    .my-10.flex.justify-center
       = link_to 'パスワード再設定', new_password_reset_path, class: 'btn btn-primary btn-warning'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -12,7 +12,7 @@
         li
           = link_to "マイテンプレート", templates_path
         li
-          = link_to "マイページ", mypage_path
+          = link_to "マイページ", profile_path
         li
           = link_to "ログアウト", logout_path, data: { turbo_method: :delete }
 

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -22,3 +22,6 @@
     p.text-md.mb-3
       = link_to 'アカウントをまだお持ちでない方', new_user_path, class: 'underline'
 
+  .my-10
+    = link_to 'Login with Google', auth_at_provider_path(provider: :google)
+

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,16 +1,25 @@
-.container.mx-auto.max-w-md.my-10
-  .w-full
+.container.mx-auto.max-w-xl.my-10
+  .w-full.flex.justify-center
     h1.text-3xl.font-bold
       | ログイン
 
-    .my-10
+  .container.mx-auto.max-w-md
+    .w-full.mt-12.mb-10
+      = link_to auth_at_provider_path(provider: :google), class: "btn px-4 py-1 flex items-center gap-2 border border-gray-500 text-slate-700 bg-white" do
+        img class="w-4 h-4" src="https://www.svgrepo.com/show/475656/google-color.svg" loading="lazy" alt="google logo"
+        span.text-sm Googleアカウントでログイン
+
+    .divider.mb-8
+      span.text-gray-700 または
+
+    .justify-center
       = form_with url: login_path do |f|
         .my-5.space-y-3
-          = f.label :email, class: 'text-xl fond-bold'
+          = f.label :email, class: 'text-xl font-bold'
           = f.email_field :email, class: 'w-full input input-borderd input-primary'
 
         .my-5.space-y-3
-          = f.label :password, class: 'text-xl fond-bold'
+          = f.label :password, class: 'text-xl font-bold'
           = f.password_field :password, class: 'w-full input input-borderd input-primary'
 
         .my-10.flex.justify-center
@@ -21,7 +30,4 @@
       = link_to 'パスワードをお忘れの方', new_password_reset_path, class: 'underline'
     p.text-md.mb-3
       = link_to 'アカウントをまだお持ちでない方', new_user_path, class: 'underline'
-
-  .my-10
-    = link_to 'Login with Google', auth_at_provider_path(provider: :google)
 

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,37 +1,47 @@
-.container.mx-auto.max-w-md.my-10
-    .w-full
-      h1.text-3xl.font-bold
-        | ユーザー登録
+.container.mx-auto.max-w-xl.my-10
+  .w-full.flex.justify-center
+    h1.text-3xl.font-bold
+      | ユーザー登録
 
-      .my-10
-        = form_with model: @user, local: true do |f|
-          - if @user.errors.any?
-            div.alert.alert-error.font-bold
-              ul
-                - @user.errors.full_messages.each do |message|
-                  li
-                    = message
+      / .btn.px-4.py-1.flex.items-center.gap-2.border.border-gray-500.text-slate-700.bg-white
+  .container.mx-auto.max-w-md
+    .w-full.mt-12.mb-10
+      = link_to auth_at_provider_path(provider: :google), class: "btn px-4 py-1 flex items-center gap-2 border border-gray-500 text-slate-700 bg-white" do
+        img class="w-4 h-4" src="https://www.svgrepo.com/show/475656/google-color.svg" loading="lazy" alt="google logo"
+        span.text-sm Googleアカウントで登録する
 
-          .my-5.space-y-3
-            = f.label :username, class: 'text-xl'
-            = f.text_field :username, class: 'w-full input input-borderd input-primary'
+    .divider.mb-8
+      span.text-gray-700 または
 
-          .my-5.space-y-3
-            = f.label :email, class: 'text-xl'
-            = f.email_field :email, class: 'w-full input input-borderd input-primary'
+    .justify-center
+      = form_with model: @user, local: true do |f|
+        - if @user.errors.any?
+          div.alert.alert-error.font-bold
+            ul
+              - @user.errors.full_messages.each do |message|
+                li
+                  = message
 
-          .my-5.space-y-3
-            = f.label :password, class: 'text-xl'
-            = f.password_field :password, class: 'w-full input input-borderd input-primary'
+        .my-5.space-y-3
+          = f.label :username, class: 'text-xl font-bold'
+          = f.text_field :username, class: 'w-full input input-borderd input-primary'
 
-          .my-5.space-y-3
-            = f.label :password_confirmation, class: 'text-xl'
-            = f.password_field :password_confirmation, class: 'w-full input input-borderd input-primary'
+        .my-5.space-y-3
+          = f.label :email, class: 'text-xl font-bold'
+          = f.email_field :email, class: 'w-full input input-borderd input-primary'
 
-          .my-5.space-y-3
-            = f.label :occupation, class: 'text-xl'
-            = f.select :occupation, User.occupations.keys.map { |k| [t("enum.user.occupation.#{k}"), k] }, { prompt: "選択して下さい" }, class: 'w-full select select-bordered select-primary'
+        .my-5.space-y-3
+          = f.label :password, class: 'text-xl font-bold'
+          = f.password_field :password, class: 'w-full input input-borderd input-primary'
 
-          .my-10.flex.justify-center
-            = f.submit '新規登録', class: 'btn btn-primary'
+        .my-5.space-y-3
+          = f.label :password_confirmation, class: 'text-xl font-bold'
+          = f.password_field :password_confirmation, class: 'w-full input input-borderd input-primary'
+
+        .my-5.space-y-3
+          = f.label :occupation, class: 'text-xl font-bold'
+          = f.select :occupation, User.occupations.keys.map { |k| [t("enum.user.occupation.#{k}"), k] }, { prompt: "選択して下さい" }, class: 'w-full select select-bordered select-primary'
+
+        .my-10.flex.justify-center
+          = f.submit '新規登録', class: 'btn btn-primary'
 

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :external]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -80,7 +80,7 @@ Rails.application.config.sorcery.configure do |config|
   # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
   # Default: `[]`
   #
-  # config.external_providers =
+  config.external_providers = %i[google]
 
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
   # Path to ca_file. By default use a internal ca-bundle.crt.
@@ -158,10 +158,13 @@ Rails.application.config.sorcery.configure do |config|
   # config.auth0.callback_url = "https://0.0.0.0:3000/oauth/callback?provider=auth0"
   # config.auth0.site = "https://example.auth0.com"
   #
-  # config.google.key = ""
-  # config.google.secret = ""
-  # config.google.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=google"
-  # config.google.user_info_mapping = {:email => "email", :username => "name"}
+  config.google.key = ENV['GOOGLE_CLIENT_ID']
+  config.google.secret = ENV['GOOGLE_CLIENT_SECRET']
+
+  config.google.callback_url = "http://localhost:3000/oauth/callback?provider=google"
+  
+  config.google.user_info_mapping = {:email => "email", :username => "name"}
+
   # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
   #
   # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.
@@ -543,7 +546,7 @@ Rails.application.config.sorcery.configure do |config|
     # Class which holds the various external provider data for this user.
     # Default: `nil`
     #
-    # user.authentications_class =
+    user.authentications_class = Authentication
 
     # User's identifier in the `authentications` class.
     # Default: `:user_id`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,12 +17,7 @@ Rails.application.routes.draw do
   get "oauth/callback", to: "oauths#callback"
   get "oauth/request/:provider", to: "oauths#oauth", as: :auth_at_provider
 
-  get "mypage", to: "profiles#show"
-  get "mypage/edit", to: "profiles#edit"
-  patch "mypage", to: "profiles#update"
-  
-  # これで代用できるっぽい　→　mypage_path が profiles_path に変わるので注意
-  # resource :profile, only: [:show, :edit, :update], path: 'mypage'
+  resource :profile, only: [:show, :edit, :update], path: 'mypage'  # パスを /mypage, /mypage/edit に
   
   resources :password_resets, only: %i[new create edit update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,11 @@ Rails.application.routes.draw do
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"
+
+  post "oauth/callback", to: "oauths#callback" # サービスによってGETとPOSTが異なる場合があるので両方作成
+  get "oauth/callback", to: "oauths#callback"
+  get "oauth/:provider", to: "oauths#oauth", as: :auth_at_provider
+
   get "mypage", to: "profiles#show"
   get "mypage/edit", to: "profiles#edit"
   patch "mypage", to: "profiles#update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,30 +1,41 @@
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
+  # 単体のページ
   root "static_pages#top"
   get "develop", to: "static_pages#develop"
   get "contact", to: "static_pages#contact"
 
+  # ユーザー関連
+  resources :users, only: %i[new create destroy]
+  
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"
 
   post "oauth/callback", to: "oauths#callback" # サービスによってGETとPOSTが異なる場合があるので両方作成
   get "oauth/callback", to: "oauths#callback"
-  get "oauth/:provider", to: "oauths#oauth", as: :auth_at_provider
+  get "oauth/request/:provider", to: "oauths#oauth", as: :auth_at_provider
 
   get "mypage", to: "profiles#show"
   get "mypage/edit", to: "profiles#edit"
   patch "mypage", to: "profiles#update"
+  
+  # これで代用できるっぽい　→　mypage_path が profiles_path に変わるので注意
+  # resource :profile, only: [:show, :edit, :update], path: 'mypage'
+  
+  resources :password_resets, only: %i[new create edit update]
+
+
+  # グラフ作成メイン画面
   get "canvas", to: "canvas#index"
   
-  resources :users, only: %i[new create destroy]
+  # マイグラフ・マイテンプレート・都市
   resources :graphs, only: %i[index show destroy]
   resources :templates, only: %i[index destroy]
   resources :cities, only: %i[index]
 
-  resources :password_resets, only: %i[new create edit update]
-
+  # API
   namespace :api do
     resources :graphs, only: %i[index show create]
     resources :templates, only: %i[index show create]

--- a/db/migrate/20240601023307_sorcery_external.rb
+++ b/db/migrate/20240601023307_sorcery_external.rb
@@ -1,0 +1,12 @@
+class SorceryExternal < ActiveRecord::Migration[7.1]
+  def change
+    create_table :authentications do |t|
+      t.integer :user_id, null: false
+      t.string :provider, :uid, null: false
+
+      t.timestamps              null: false
+    end
+
+    add_index :authentications, [:provider, :uid]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_30_131258) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_01_023307) do
+  create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
   create_table "cities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.json "data", null: false


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/36

本番環境の準備は整っていますが，このプルリクエストをマージした後，本番環境でのテストが完了したところでcloseします。

- Sorceryのexternalサブモジュールを利用しました
- マニュアル通り，Authenticationsテーブル・クラスを作成し，Userモデルと関連付けを行いました
- oauthesコントローラーを作成し，認証の発火とコールバック情報を制御するようにしました。 
- Googleで新規登録を行ったのち，必須項目となっている職業欄を追加してもらうために，プロフィール編集ページへと誘導するようにしました
- 万が一，職業欄が空欄の状態でブラウザを閉じてしまった場合を想定して，application_controllerのbefore_actionで，ログインユーザーの職業欄が空欄の場合に，プロフィール編集ページへと遷移するように実装しました
- Googleアカウントを紐づけたユーザーは，マイページからそれが分かるようにしました。
- Googleアカウントを紐づけたユーザーは，メールアドレスを変更できないようにしました。
- ログイン・ユーザー登録画面のレイアウトを調整しました。 


https://i.gyazo.com/bcfd9662c6a7b9c10f9e15d7c8d4d9f0.gif