### PR TITLE
Sorceryのgoogle_callback_urlをconfigで管理するよう設定

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -161,7 +161,7 @@ Rails.application.config.sorcery.configure do |config|
   config.google.key = ENV['GOOGLE_CLIENT_ID']
   config.google.secret = ENV['GOOGLE_CLIENT_SECRET']
 
-  config.google.callback_url = "http://localhost:3000/oauth/callback?provider=google"
+  config.google.callback_url = Settings.sorcery[:google_callback_url]
   
   config.google.user_info_mapping = {:email => "email", :username => "name"}
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,4 @@
 default_url_options:
   host: 'localhost:3000'
+sorcery:
+  google_callback_url: "http://localhost:3000/oauth/callback?provider=google"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,5 @@
 default_url_options:
   host: 'u-on-zu.com'
   protocol: 'https'
+sorcery:
+  google_callback_url: "http://u-on-zu.com/oauth/callback?provider=google"


### PR DESCRIPTION
- Google外部認証のcallback_urlを，本番環境に対応できていなかったので追加しました。
- gem configを用いて，環境毎に異なるURLへリダイレクトするようにしています。