### PR TITLE
config.time_zoneをTokyoに設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Myapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
+    config.time_zone = "Tokyo" # タイムゾーンを日本時間に設定
 
     config.generators.template_engine = :slim # テンプレートエンジンをslimに設定
 


### PR DESCRIPTION
- タイムゾーンを環境で統一するために，application.rbで ``` config.time_zone = 'Tokyo' ``` を設定しました。
- 開発環境で，Time.current や データのcreated_at が UTC +0900になっていることを確認しました
- マージして本番環境で確認後，closeします