### PR TITLE
グラフ作成中にページを閉じても、途中から復旧できるようにする

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,4 +5,7 @@
 import { application } from "./application"
 
 import HelloController from "./hello_controller"
+import NewGraphController from "./new_graph_controller"
+
 application.register("hello", HelloController)
+application.register("new-graph", NewGraphController)

--- a/app/javascript/controllers/new_graph_controller.js
+++ b/app/javascript/controllers/new_graph_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.addEventListener('click', this.handleClick.bind(this))
+  }
+
+  handleClick(event) {
+    if (!confirm('新規グラフを作成しますか？')) {
+      event.preventDefault()
+    } else {
+      // ここに実行したいJavaScriptのコードを書く
+    }
+  }
+}

--- a/app/javascript/controllers/new_graph_controller.js
+++ b/app/javascript/controllers/new_graph_controller.js
@@ -6,10 +6,12 @@ export default class extends Controller {
   }
 
   handleClick(event) {
-    if (!confirm('新規グラフを作成しますか？')) {
+    if (!confirm('一時的に保存されている内容があります。新しくグラフを作成しますか？')) {
       event.preventDefault()
     } else {
       // ここに実行したいJavaScriptのコードを書く
+      localStorage.removeItem('cityId');
+      localStorage.removeItem('settingValues');
     }
   }
 }

--- a/app/javascript/controllers/new_graph_controller.js
+++ b/app/javascript/controllers/new_graph_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   }
 
   handleClick(event) {
-    if (!confirm('一時的に保存されている内容があります。新しくグラフを作成しますか？')) {
+    if (!confirm('一時的に保存されている内容があります。\n新しくグラフを作成しますか？')) {
       event.preventDefault()
     } else {
       // ここに実行したいJavaScriptのコードを書く

--- a/app/javascript/react/canvas/components/fetch_city_data/city_search_box.jsx
+++ b/app/javascript/react/canvas/components/fetch_city_data/city_search_box.jsx
@@ -37,7 +37,6 @@ export default function CitySearchBox({cityIdMapping, setCityId}) {
         flexDirection: 'row',
         justifyContent: 'center',
         alignItems: 'center',
-        alignItems: 'start',
         paddingTop: '40px'
       }}
       // role="presentation"

--- a/app/javascript/react/canvas/components/fetch_city_data/city_search_box.jsx
+++ b/app/javascript/react/canvas/components/fetch_city_data/city_search_box.jsx
@@ -36,7 +36,7 @@ export default function CitySearchBox({cityIdMapping, setCityId}) {
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'center',
-        alignItems: 'center',
+        alignItems: 'start',
         paddingTop: '40px'
       }}
       // role="presentation"

--- a/app/javascript/react/canvas/hooks/useCity.js
+++ b/app/javascript/react/canvas/hooks/useCity.js
@@ -12,6 +12,8 @@ export const useCity = (cityId) => {             //idを引数で受ける
           const cityData = await response.json();
           if (cityData) {
             setCity(cityData);  //cityデータをstateにセット
+            console.log('localStorageを更新します', cityId)
+            localStorage.setItem('cityId', JSON.stringify(cityId));
           } else {
             console.log('city not found');
           }

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -107,33 +107,21 @@ export default function CanvasApp() {
     openRightDrawer ? handleCloseRightDrawer() : handleOpenRightDrawer()
   }
 
-  // グラフ設定値のステートをまとめて宣言
+  //********** ログイン状態確認のfetch処理を先に実行 **********//
+  // loadingフラグを先にたてておく&ログイン状態の取得を先に実行
+
+  // ----------- ログイン状態確認処理 ------------- //
+  //ログイン状態を取得。fetch処理完了でloginCheckLoadingをfalseに
+  const { loggedIn, loginCheckLoading } = checkLoggedIn();
+
+
+  //***************** 各ステート・ハンドラの宣言 *********************//
+  // グラフ設定値
   // localStorageから値を取得できた場合はそれを格納。空の場合初期値はinitialSettingValues.jsで定義
   const [settingValues, setSettingValues] = useState(() => {
     const savedState = localStorage.getItem('settingValues');
     return savedState ? JSON.parse(savedState) : initialSettingValues;
   });
-
-  //都市IDをstateで管理
-  // localStorageから値を取得できた場合はそれを格納。空の場合初期値は1（東京）に設定
-  const [cityId, setCityId] = useState(() => {
-    const savedCityId = localStorage.getItem('cityId');
-    return savedCityId ? JSON.parse(savedCityId) : 1;  
-  })
-
-
-  //グラフに投入するデータをstateで管理。初期値はcityIdのfetchエラーを想定して東京のモックデータにしておく。
-  const [graphInput, setGraphInput] = useState(data_tokyo);
-
-  //テンプレート一覧の選択肢をstateで管理。初期値は空の配列で，未ログインなら更新しない。
-  const [templateOptions, setTemplateOptions] = useState([])
-
-  // 選択中のテンプレートをstateで管理
-  const [selectedTemplate, setSelectedTemplate] = useState(null)
-  // テンプレート選択セレクトボックスのonChangeハンドラ
-  const handleTemplateChange = (event) => {
-    setSelectedTemplate(event.target.value);
-  }
 
   // グラフ設定値ステートの変更を監視して逐一localStorageに保存する
   useEffect(() => {
@@ -144,6 +132,30 @@ export default function CanvasApp() {
   //グラフ設定値更新ハンドラ（共通化して対象のみ更新する）
   const handleValueChange = (name, value) => {
     setSettingValues({...settingValues, [name]: value});
+  }
+
+
+  //都市ID
+  // localStorageから値を取得できた場合はそれを格納。空の場合初期値は1（東京）に設定
+  // localStorageへの保存はuseCity内で行う
+  const [cityId, setCityId] = useState(() => {
+    const savedCityId = localStorage.getItem('cityId');
+    return savedCityId ? JSON.parse(savedCityId) : 1;  
+  })
+
+  //グラフに投入する気候データ
+  //初期値はcityIdのfetchエラーを想定して東京のモックデータにしておく。
+  const [graphInput, setGraphInput] = useState(data_tokyo);
+
+  //テンプレート一覧の選択肢
+  //初期値は空の配列で，未ログインなら更新しない。
+  const [templateOptions, setTemplateOptions] = useState([])
+
+  //選択中のテンプレート
+  const [selectedTemplate, setSelectedTemplate] = useState(null)
+  // テンプレート選択セレクトボックスのonChangeハンドラ
+  const handleTemplateChange = (event) => {
+    setSelectedTemplate(event.target.value);
   }
 
   //********** useEffectによる自動fetch処理 **********//
@@ -167,12 +179,6 @@ export default function CanvasApp() {
       }
     }
   },[city]);
-  
-
-  // ----------- ログイン状態確認処理 ------------- //
-  //ログイン状態を取得。fetch処理完了でloginCheckLoadingをfalseに
-  const { loggedIn, loginCheckLoading } = checkLoggedIn();
-
   
   // --------- マイグラフ(graph)処理 ----------- //
   //マイグラフ一覧から遷移した際に加えられるパラメータを利用してマイグラフデータを取得。
@@ -215,7 +221,6 @@ export default function CanvasApp() {
 
   return (
     <>
-      {/* <div>{ loggedIn ? 'あああああ' : 'いいいいい' }</div> */}
       {/* 操作メニューバー */}
       <Box
         sx={{
@@ -275,36 +280,33 @@ export default function CanvasApp() {
         </ButtonGroup>
       </Box>
 
-        {/* 画像DLモーダル */}
-        <DownloadImageButton 
-          layoutHeight={settingValues.layoutHeight}  
-          layoutWidth={settingValues.layoutWidth}
-          graphTitle={settingValues.title}
-          open={openDLImageModal}
-          handleClose={handleCloseDLImageModal}
-        />
+      {/* 画像DLモーダル */}
+      <DownloadImageButton 
+        layoutHeight={settingValues.layoutHeight}  
+        layoutWidth={settingValues.layoutWidth}
+        graphTitle={settingValues.title}
+        open={openDLImageModal}
+        handleClose={handleCloseDLImageModal}
+      />
 
-        {/* マイグラフ登録モーダル */}
-        <MyGraphModal 
-          graphSetting={settingValues}
-          cityId={cityId}
-          open={openMyGraphModal}
-          handleClose={handleCloseMyGraphModal} />
+      {/* マイグラフ登録モーダル */}
+      <MyGraphModal 
+        graphSetting={settingValues}
+        cityId={cityId}
+        open={openMyGraphModal}
+        handleClose={handleCloseMyGraphModal} />
 
-        {/* マイテンプレート登録モーダル */}
-        <MyTemplateModal
-          graphSetting={settingValues}
-          open={openMyTemplateModal}
-          handleClose={handleCloseMyTemplateModal} />
+      {/* マイテンプレート登録モーダル */}
+      <MyTemplateModal
+        graphSetting={settingValues}
+        open={openMyTemplateModal}
+        handleClose={handleCloseMyTemplateModal} />
 
       {/* グラフ描画と右ドロワーをラップしたBox */}
       <Box sx={{ display: 'flex' }}>
 
         {/* open時に右ドロワーの幅だけ縮むMain描画部分 */}
         <Main open={openRightDrawer} >
-
-          {/* <div className='text-xl'> {graph.graph_setting.settings.dotSize} </div>
-          <div className='text-xl'> {JSON.stringify(graph.graph_setting)} </div> */}
 
           {/* Rechartsグラフ描画部分 */}
           <div className='flex justify-center items-center'>
@@ -356,6 +358,7 @@ export default function CanvasApp() {
             </IconButton>
           </Box>
 
+          {/* テンプレート適用ボタン・セレクタ */}
           <Box backgroundColor="" marginBottom='60px' width='100%'>
             <Tooltip title={loggedIn ? "" : "テンプレート機能はログイン後に利用できます" }>
               <span>
@@ -403,6 +406,7 @@ export default function CanvasApp() {
             </FormControl>
           </Box>
 
+          {/* テンプレート保存ボタン */}
           <Box width='100%'>
             <Divider sx={{ borderBottomWidth: 2, borderColor: '#b9b1b1' }} />
           </Box>
@@ -433,8 +437,6 @@ export default function CanvasApp() {
 
           {/* グラフ設定値入力コンポーネント */}
           <GraphSettings settingValues={settingValues} handleValueChange={handleValueChange}/>
-          {/* <div className='my-10'>ここはGraphSettingsの外（mainコンポーネント） {lineDotSize}</div> */}
-
         </Drawer>
       </Box>
 

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -107,8 +107,20 @@ export default function CanvasApp() {
     openRightDrawer ? handleCloseRightDrawer() : handleOpenRightDrawer()
   }
 
-  //都市IDをstateで管理。初期値は1（東京）
-  const [cityId, setCityId] = useState(1); 
+  // グラフ設定値のステートをまとめて宣言
+  // localStorageから値を取得できた場合はそれを格納。空の場合初期値はinitialSettingValues.jsで定義
+  const [settingValues, setSettingValues] = useState(() => {
+    const savedState = localStorage.getItem('settingValues');
+    return savedState ? JSON.parse(savedState) : initialSettingValues;
+  });
+
+  //都市IDをstateで管理
+  // localStorageから値を取得できた場合はそれを格納。空の場合初期値は1（東京）に設定
+  const [cityId, setCityId] = useState(() => {
+    const savedCityId = localStorage.getItem('cityId');
+    return savedCityId ? JSON.parse(savedCityId) : 1;  
+  })
+
 
   //グラフに投入するデータをstateで管理。初期値はcityIdのfetchエラーを想定して東京のモックデータにしておく。
   const [graphInput, setGraphInput] = useState(data_tokyo);
@@ -123,8 +135,12 @@ export default function CanvasApp() {
     setSelectedTemplate(event.target.value);
   }
 
-  // グラフ設定値のステートをまとめて宣言
-  const [settingValues, setSettingValues] = useState(initialSettingValues);   //初期値はinitialSettingValues.jsで定義
+  // グラフ設定値ステートの変更を監視して逐一localStorageに保存する
+  useEffect(() => {
+    console.log('settingValuesが更新されました。localStorageを更新します', settingValues)
+    localStorage.setItem('settingValues', JSON.stringify(settingValues));
+  }, [settingValues]);
+
   //グラフ設定値更新ハンドラ（共通化して対象のみ更新する）
   const handleValueChange = (name, value) => {
     setSettingValues({...settingValues, [name]: value});

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -6,13 +6,15 @@
             path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"
       ul class="menu menu-lg dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52" tabindex="0"
         li
-          = link_to "新規グラフ作成", canvas_path
+          = link_to "新規グラフ作成", canvas_path, data: { controller: 'new-graph'}
         li
           = link_to "新規ユーザー登録", new_user_path
         li
           = link_to "ログイン", login_path
+        li
+          = link_to "トップページ", root_path
 
-    = link_to "U-ON-ZU!", root_path, class: "btn btn-ghost text-xl"
+    = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl"
 
   .flex-none
     = link_to "新規ユーザー登録", new_user_path, class: "btn btn-ghost text-xl"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,9 +14,11 @@
         li
           = link_to "マイページ", profile_path
         li
+          = link_to "トップページ", root_path
+        li
           = link_to "ログアウト", logout_path, data: { turbo_method: :delete }
 
-    = link_to "U-ON-ZU!", root_path, class: "btn btn-ghost text-xl"
+    = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl"
 
   .flex-none
     .dropdown

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -6,7 +6,7 @@
           path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"
       ul class="menu menu-lg dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52" tabindex="0"
         li
-          = link_to "新規グラフ作成", canvas_path
+          = link_to "新規グラフ作成", canvas_path, data: { controller: 'new-graph'}
         li
           = link_to "マイグラフ", graphs_path
         li


### PR DESCRIPTION
次のissueを完了しました
https://github.com/g-sawada/u-on-zu/issues/199

- index.jsxやuseCityのuseEffectを利用して，cityIdとsettingValuesに変更があった際，逐一localStorageに情報を保存するようにし，ステートの初期値にlocalStorageの値を入れるようにしました
- ヘッダーの「新規グラフ」作成をクリックした際，Stimulusに設定したJSで，localStorageのcityIdやsettingValuesを削除してからページ遷移するようにしました
- 「U-ON-ZU」のロゴをクリックした時は，localStorageを削除せずにcanvas画面が表示されるようにしました
- ヘッダーにトップページのリンクをつけました

https://i.gyazo.com/d27686568502d5bf987e7be9c6f35bdf.gif

https://gyazo.com/9729ef332ee31703eb1315603fe83903

close #199 


