### PR TITLE
canvas_pathへのリンク遷移にdata-turbolinks='false'を実装

### DIFF
--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -13,8 +13,8 @@
           = link_to "ログイン", login_path
         li
           = link_to "トップページ", root_path
-
-    = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl"
+    div data-turbolinks="false"
+      = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl"
 
   .flex-none
     = link_to "新規ユーザー登録", new_user_path, class: "btn btn-ghost text-xl"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -17,8 +17,8 @@
           = link_to "トップページ", root_path
         li
           = link_to "ログアウト", logout_path, data: { turbo_method: :delete }
-
-    = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl"
+    div data-turbolinks="false"
+      = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl"
 
   .flex-none
     .dropdown

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -5,7 +5,8 @@
     = image_tag 'toppage_uonzu.png', class: "bg-cover bg-center bg-no-repeat h-[300px] w-[300px] mx-auto mb-6 shadow-2xl rounded-md"
     div.mx-auto
       p.text-2xl.mx-auto 雨温図を自由に簡単に作成できます
-      = link_to "さっそく使ってみる", canvas_path, class: "btn btn-primary my-6"
+      div data-turbolinks="false"
+        = link_to "さっそく使ってみる", canvas_path, class: "btn btn-primary my-6"
 
       .flex.justify-center.space-x-8
         = link_to "新規ユーザー登録", new_user_path, class: "btn btn-outline"


### PR DESCRIPTION
- グラフメイン画面を表示した際，一瞬だけ前の画面の残像が残ってしまう問題を，turbolinksによるものと考え，canvas_pathのリンクボタンに``` data-turbolinks='false' ``` を実装しました

