### PR TITLE
フラッシュメッセージをトースト式に変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym
+    when :info then "bg-info"
+    when :success then "bg-success"
+    when :warning  then "bg-warning"
+    when :error  then "bg-error"
+    else "bg-gray-500"
+    end
+  end
 end

--- a/app/views/shared/_flash_message.html.slim
+++ b/app/views/shared/_flash_message.html.slim
@@ -1,3 +1,5 @@
+/ flash_background_colorはhelpersで定義
 - flash.each do |message_type, message|
-  div class="alert alert-#{message_type} mb-10 rounded-none font-bold"
-    = message
+  div class="#{ flash_background_color(message_type) } animate-flash fixed top-16 translate-x-1/2 right-0 z-30 w-fit max-w-[90%] rounded-none py-2 px-6 shadow-xl"
+    p.text-sm.font-bold
+      = message

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,12 +3,26 @@ const withMT = require("@material-tailwind/react/utils/withMT");
 module.exports = withMT({
   theme: {
     extend: {
+      boxShadow: {
+        'xl': '5px 10px 8px -5px rgb(0 0 0 / 0.3)',
+      },
       fontFamily: {
         sans: ['Helvetica', 'Arial', 'sans-serif'],
         serif: ['Merriweather', 'serif'],
         },
+      keyframes: {
+        flashFade: {
+          "0%": { transform: "translateX(180px)", opacity: 0 },
+          "10%": { transform: "translateX(0)", opacity: 1 },
+          "90%": { transform: "translateX(0)", opacity: 1 },
+          "100%": { transform: "translateX(180px)", opacity: 0 },
+        },
+      },
+      animation: {
+        flash: "flashFade 7.0s forwards",
       },
     },
+  },
   content: [
     './app/views/**/*.html.erb',
     './app/views/**/*.html.slim',
@@ -44,9 +58,9 @@ module.exports = withMT({
           'base-300' : '#b9b1b1',
           'base-content' : '#100f0f',
 
-          'info' : '#1c92f2',
-          'success' : '#009485',
-          'warning' : '#ff9900',
+          'info' : '#7cc0f8',
+          'success' : '#00c7b3',
+          'warning' : '#ffad33',
           'error' : '#ff5724',
           // 'error' : '#e65023',
 


### PR DESCRIPTION
次のissueを完了しました
https://github.com/g-sawada/u-on-zu/issues/218

- tailwind.config.jsにアニメーションのclassを独自に定義し，パーシャルビューで呼び出すようにしました
- daisyUIのalertクラスでは，影をつけることができなかったので削除し，application_helper.rbに定義したflash_background_colorで，flashメッセージのタイプによってbgを切り替えられるようにしました
- shadow-xlを独自にアレンジしました

https://i.gyazo.com/cb7313ee39da00ec4a9c71f0adda0be6.gif

close #218 