### PR TITLE
ボタンデザインの統一・ヘッダーレイアウトの編集

### DIFF
--- a/app/javascript/react/canvas/components/fetch_city_data/city_search_box.jsx
+++ b/app/javascript/react/canvas/components/fetch_city_data/city_search_box.jsx
@@ -37,7 +37,7 @@ export default function CitySearchBox({cityIdMapping, setCityId}) {
         flexDirection: 'row',
         justifyContent: 'center',
         alignItems: 'start',
-        paddingTop: '40px'
+        paddingTop: '70px'
       }}
       // role="presentation"
     >

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -26,6 +26,8 @@
         .w-full.text-lg
           = t("enum.user.occupation.#{@user.occupation}")
     
-    .mt-20.flex.justify-center.gap-20
+    .mt-15.flex.justify-center.gap-20
       = link_to '変更する', edit_profile_path, class: 'btn btn-primary'
       = link_to 'パスワード再設定', new_password_reset_path, class: 'btn btn-primary btn-warning'
+    .mt-10.flex.justify-end
+      = link_to "▶ ログアウト", logout_path, data: { turbo_method: :delete }, class: "font-bold btn btn-ghost btn-sm"

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -8,17 +8,17 @@
         li
           = link_to "新規グラフ作成", canvas_path, data: { controller: 'new-graph'}
         li
-          = link_to "新規ユーザー登録", new_user_path
+          = link_to "ユーザー登録", new_user_path
         li
           = link_to "ログイン", login_path
         li
           = link_to "トップページ", root_path
 
-    = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl", data: { turbo: false }
+    = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-2xl", data: { turbo: false }
 
-  .flex-none
-    = link_to "新規ユーザー登録", new_user_path, class: "btn btn-ghost text-xl"
-    = link_to "ログイン", login_path, class: "btn btn-ghost text-xl"
+  .flex-none.gap-x-2
+    = link_to "ユーザー登録", new_user_path, class: "btn btn-warning text-md"
+    = link_to "ログイン", login_path, class: "btn btn-neutral text-md"
     .dropdown
       .btn.btn-ghost tabindex="0" role="button"
         svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -21,6 +21,14 @@
       = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-2xl", data: { turbo: false }
 
   .flex-none
+    p.font-bold.text-sm.mr-1
+      | ログイン中: 
+    = link_to profile_path, class: "btn btn-ghost btn-sm py-0 px-2 text-md" do
+      = current_user.username
+      - if current_user.authentications.present?
+        .bg-white.rounded-full
+          img class="w-4 h-4" src="https://www.svgrepo.com/show/475656/google-color.svg" loading="lazy" alt="google logo"
+
     .dropdown
       .btn.btn-ghost tabindex="0" role="button"
         svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -18,7 +18,7 @@
         li
           = link_to "ログアウト", logout_path, data: { turbo_method: :delete }
     div data-turbolinks="false"
-      = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-xl", data: { turbo: false }
+      = link_to "U-ON-ZU!", canvas_path, class: "btn btn-ghost text-2xl", data: { turbo: false }
 
   .flex-none
     .dropdown

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -6,8 +6,8 @@
     div.mx-auto
       p.text-2xl.mx-auto 雨温図を自由に簡単に作成できます
       div data-turbolinks="false"
-        = link_to "さっそく使ってみる", canvas_path, class: "btn btn-primary my-6", data: { turbo: false }
+        = link_to "さっそく使ってみる", canvas_path, class: "btn btn-primary btn-lg text-lg my-6", data: { turbo: false }
 
       .flex.justify-center.space-x-8
-        = link_to "新規ユーザー登録", new_user_path, class: "btn btn-outline"
-        = link_to "ログイン", login_path, class: "btn btn-outline"
+        = link_to "ユーザー登録", new_user_path, class: "btn btn-warning btn-lg text-lg"
+        = link_to "ログイン", login_path, class: "btn btn-neutral btn-lg text-lg"

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -23,7 +23,7 @@
           = f.password_field :password, class: 'w-full input input-borderd input-primary'
 
         .my-10.flex.justify-center
-          = f.submit 'ログイン', class: 'btn btn-primary', data: { disable_with: 'ログイン' }
+          = f.submit 'ログイン', class: 'btn btn-neutral', data: { disable_with: 'ログイン' }
   
   .w-full.text-end
     p.text-md.mb-3

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -43,5 +43,5 @@
           = f.select :occupation, User.occupations.keys.map { |k| [t("enum.user.occupation.#{k}"), k] }, { prompt: "選択して下さい" }, class: 'w-full select select-bordered select-primary'
 
         .my-10.flex.justify-center
-          = f.submit '新規登録', class: 'btn btn-primary'
+          = f.submit '新規ユーザー登録', class: 'btn btn-warning '
 


### PR DESCRIPTION
次のissueを完了しました
https://github.com/g-sawada/u-on-zu/issues/165
https://github.com/g-sawada/u-on-zu/issues/188
https://github.com/g-sawada/u-on-zu/issues/69


- ログイン中ヘッダーにcurrent_user.usernameを表示し，マイページへのリンクボタンを設置しました
- svgは，publicに素材を入れて直接読み込むようにしました
- ボタンのデザインを全体で統一しました。
close #165 
close #188 
close #69 