### PR TITLE
画像DL数のカウントをできるようにする

### DIFF
--- a/app/controllers/api/download_counts_controller.rb
+++ b/app/controllers/api/download_counts_controller.rb
@@ -1,0 +1,15 @@
+  # POST /api/download_counts
+  def create
+    city = City.find(params[:city_id])
+    download_count = city.download_counts.new
+
+    if logged_in?
+      download_count.user = current_user
+    end
+
+    if download_count.save
+      render json: { download_count: download_count }, status: :ok
+    else
+      render json: { error: '保存に失敗しました。' }, status: :unprocessable_entity
+    end
+  end

--- a/app/controllers/api/download_counts_controller.rb
+++ b/app/controllers/api/download_counts_controller.rb
@@ -1,8 +1,11 @@
+class Api::DownloadCountsController < Api::BaseController
   # POST /api/download_counts
   def create
-    city = City.find(params[:city_id])
+    # binding.pry
+    city = City.find(download_image_params[:city_id])
     download_count = city.download_counts.new
 
+    # ログイン中なら，ユーザー情報も追加で保存（user_idはNULLを認めている）
     if logged_in?
       download_count.user = current_user
     end
@@ -13,3 +16,9 @@
       render json: { error: '保存に失敗しました。' }, status: :unprocessable_entity
     end
   end
+
+  private
+  def download_image_params
+    params.require(:download_image).permit(:city_id)
+  end
+end

--- a/app/javascript/react/canvas/index.jsx
+++ b/app/javascript/react/canvas/index.jsx
@@ -310,11 +310,13 @@ export default function CanvasApp() {
 
       {/* 画像DLモーダル */}
       <DownloadImageButton 
-        layoutHeight={settingValues.layoutHeight}  
-        layoutWidth={settingValues.layoutWidth}
-        graphTitle={settingValues.title}
+        // layoutHeight={settingValues.layoutHeight}  
+        // layoutWidth={settingValues.layoutWidth}
+        // graphTitle={settingValues.title}
+        settingValues={settingValues}
         open={openDLImageModal}
         handleClose={handleCloseDLImageModal}
+        cityId={cityId}
       />
 
       {/* マイグラフ登録モーダル */}

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,5 +1,6 @@
 class City < ApplicationRecord
   has_many :graphs
+  has_many :download_counts
 
   validates :name, presence: true
   validates :data, presence: true

--- a/app/models/download_count.rb
+++ b/app/models/download_count.rb
@@ -1,0 +1,4 @@
+class DownloadCount < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :city
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   has_many :graphs, dependent: :destroy
   has_many :templates, dependent: :destroy
+  has_many :download_counts
 
   accepts_nested_attributes_for :authentications
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     resources :templates, only: %i[index show create]
     resources :cities, only: %i[index show]
     get "check_login", to: "user_sessions#check_login"
+    post "download_counts", to: "download_counts#create"
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20240607103330_create_download_counts.rb
+++ b/db/migrate/20240607103330_create_download_counts.rb
@@ -1,0 +1,10 @@
+class CreateDownloadCounts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :download_counts do |t|
+      t.references :user, null: true, foreign_key: true
+      t.references :city, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_01_023307) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_07_103330) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -25,6 +25,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_01_023307) do
     t.json "data", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "download_counts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "city_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["city_id"], name: "index_download_counts_on_city_id"
+    t.index ["user_id"], name: "index_download_counts_on_user_id"
   end
 
   create_table "graph_settings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -71,6 +80,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_01_023307) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "download_counts", "cities"
+  add_foreign_key "download_counts", "users"
   add_foreign_key "graphs", "cities"
   add_foreign_key "graphs", "users"
   add_foreign_key "templates", "users"


### PR DESCRIPTION
次のissueの項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/216


- download_countsテーブルを作成し，user_idとcity_idを外部キーにとるようにしました
- download_countsのレコード数=DL数となります。
- user_idのnullを認め，非ログインユーザーの場合でも登録できるようにしています。
- 画像DLモーダルにuseFormを導入したことで，サイズの初期値が更新されないバグが発生していたので，修正しました

close #216 