### PR TITLE
Minimagickのリサイズと余白背景の設定

### DIFF
--- a/app/uploaders/graph_thumbnail_uploader.rb
+++ b/app/uploaders/graph_thumbnail_uploader.rb
@@ -1,7 +1,7 @@
 class GraphThumbnailUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
   # storage :file
@@ -23,7 +23,8 @@ class GraphThumbnailUploader < CarrierWave::Uploader::Base
   # end
 
   # Process files as they are uploaded:
-  # process scale: [200, 300]
+  process resize_and_pad: [300, 300, background='#ffffff', gravity='Center']
+
   #
   # def scale(width, height)
   #   # do something


### PR DESCRIPTION
次のissueを完了しました
https://github.com/g-sawada/u-on-zu/issues/241

- ひとまず，300x300，縦横の短い方に生じた余白は白色で背景を埋めるように設定しました
close #241 