### PR TITLE
サムネイル画像が無い場合にプレースホルダー画像を表示する

### DIFF
--- a/app/views/graphs/_card_view.html.slim
+++ b/app/views/graphs/_card_view.html.slim
@@ -4,7 +4,10 @@
       = link_to graph_path(graph), class: "block bg-white rounded-lg shadow hover:shadow-lg transform hover:-translate-y-1 transition duration-500" do
         h2.text-xl.font-bold.px-4.py-2.mb-2
           = graph.title
-        = image_tag graph.thumbnail.url, alt: "サムネイル画像", class: "w-full object-cover rounded-md"
+        - if graph.thumbnail?
+          = image_tag graph.thumbnail.url, alt: "サムネイル画像", class: "w-full object-cover rounded-b-md"
+        - else
+          = image_tag "https://placehold.jp/30/d3d3d3/ffffff/300x300.png?text=No+Image", alt: "サムネイル画像", class: "w-full object-cover rounded-b-md"
       .flex.justify-end.mt-2.space-x-2
         = link_to canvas_path(graph: graph.id), class: 'btn btn-sm btn-secondary h-5 p-2' do
           img class="inline-block w-4 h-4 stroke-current" src="/images/edit_chart.svg" alt=""


### PR DESCRIPTION
マイグラフ一覧のカードビューに次の分岐処理を実装し，サムネイル機能実装前にグラフを作成した場合にプレースホルダー画像が表示されるようにしました

```
  - if graph.thumbnail?
    = image_tag graph.thumbnail.url, alt: "サムネイル画像", class: "w-full object-cover rounded-b-md"
  - else
    = image_tag "https://placehold.jp/30/d3d3d3/ffffff/300x300.png?text=No+Image", alt: "サムネイル画像", class: "w-full object-cover rounded-b-md"

```