### PR TITLE
ユーザー削除機能

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,6 +26,8 @@ class UsersController < ApplicationController
 
   # ユーザー削除処理
   def destroy
+    current_user.destroy!
+    redirect_to root_path, status: :see_other ,success: 'ユーザーを削除しました'
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   has_many :graphs, dependent: :destroy
   has_many :templates, dependent: :destroy
-  has_many :download_counts
+  has_many :download_counts, dependent: :nullify
 
   accepts_nested_attributes_for :authentications
 

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -33,3 +33,31 @@
       = link_to 'パスワード再設定', new_password_reset_path, class: 'btn btn-primary btn-warning'
     .mt-10.flex.justify-end
       = link_to "▶ ログアウト", logout_path, data: { turbo_method: :delete }, class: "font-bold btn btn-ghost btn-sm"
+
+    .mt-5.flex.justify-end
+      button.btn.btn-sm.btn-ghost onclick="my_modal_4.showModal()" ▶ユーザー登録を削除 
+
+    / 退会モーダル
+    dialog#my_modal_4.modal
+      .modal-box.max-w-2xl
+        h3.font-bold.text-xl
+          | 本当にユーザー登録を削除しますか？
+        .p-5
+          p.py-4
+            | ユーザー情報は<strong>完全に削除</strong>されます。
+            ul.list-disc.ml-5.space-y-3
+              li
+                | 保存したマイグラフ
+              li
+                | 保存したマイテンプレート
+          
+          p.py-4 
+            | これらの情報は復元できませんので、ご注意ください。
+
+        .modal-action.justify-center
+          form method="dialog"
+            .flex.justify-center.space-x-20
+              button.btn
+                | キャンセル
+
+              = link_to "ユーザー登録削除を実行", user_path(@user), method: :delete, data: { turbo_method: :delete }, class: "btn btn-error" 

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -35,24 +35,26 @@
       = link_to "▶ ログアウト", logout_path, data: { turbo_method: :delete }, class: "font-bold btn btn-ghost btn-sm"
 
     .mt-5.flex.justify-end
-      button.btn.btn-sm.btn-ghost onclick="my_modal_4.showModal()" ▶ユーザー登録を削除 
+      button.btn.btn-sm.btn-ghost onclick="my_modal_4.showModal()" ▶ユーザーを削除
 
     / 退会モーダル
     dialog#my_modal_4.modal
       .modal-box.max-w-2xl
         h3.font-bold.text-xl
-          | 本当にユーザー登録を削除しますか？
+          | 本当にユーザーを削除しますか？
         .p-5
           p.py-4
-            | ユーザー情報は<strong>完全に削除</strong>されます。
+            | 次の情報は<strong>完全に削除</strong>されます。
             ul.list-disc.ml-5.space-y-3
+              li
+                | 全てのユーザー情報
               li
                 | 保存したマイグラフ
               li
                 | 保存したマイテンプレート
           
           p.py-4 
-            | これらの情報は復元できませんので、ご注意ください。
+            | これらの情報は<strong>復元できません</strong>ので、ご注意ください。
 
         .modal-action.justify-center
           form method="dialog"
@@ -60,4 +62,4 @@
               button.btn
                 | キャンセル
 
-              = link_to "ユーザー登録削除を実行", user_path(@user), method: :delete, data: { turbo_method: :delete }, class: "btn btn-error" 
+              = link_to "ユーザー削除を実行", user_path(@user), method: :delete, data: { turbo_method: :delete }, class: "btn btn-error" 


### PR DESCRIPTION
次のissueを完了しました
https://github.com/g-sawada/u-on-zu/issues/42

- daisyUIのモダールを使ってマイページに実装しました
- 退会後はトップページに遷移させるようにしました
- DownloadCountはユーザーが削除されてもレコードを残したいため，Userモデルのhas_manyに```dependent: :nullify``` を追記しました。


close #42 