### PR TITLE
graph一覧画面に検索機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,9 @@ gem "mini_magick"
 # 画像アップロードのaws s3連携
 gem 'fog-aws' 
 
+# 検索機能
+gem 'ransack'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,10 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.1)
@@ -416,6 +420,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-i18n (~> 7.0.0)
+  ransack
   seed-fu
   selenium-webdriver
   slim-rails

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -2,7 +2,8 @@ class GraphsController < ApplicationController
   before_action :require_login
 
   def index
-    @graphs = current_user.graphs
+    @q = current_user.graphs.ransack(params[:q])
+    @graphs = @q.result(distinct: true).order(created_at: :desc)
     @view_mode = params[:view_mode] || cookies[:view_mode] || "table" # デフォルトはテーブル表示
     cookies[:view_mode] = @view_mode
   end

--- a/app/models/graph.rb
+++ b/app/models/graph.rb
@@ -9,4 +9,12 @@ class Graph < ApplicationRecord
   validates :city_id, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validates :note, length: { maximum: 65_535 }
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[title note created_at updated_at]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    []
+  end
 end

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -10,7 +10,8 @@
     = link_to graphs_path(view_mode: 'card'), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do
       img class="inline-block w-8 h-8 stroke-current" src="/images/squares-four.svg" alt=""
 
-  = search_form q: @q, url: graphs_path do |f|
+  / 検索フォーム
+  = search_form_for @q, url: graphs_path do |f|
     .flex.justify-end.space-x-1.mb-10
       = f.search_field :title_cont, class: 'form-input w-96 h-8 rounded-none', placeholder: 'グラフ名で検索'
       = f.submit '検索', class: 'btn btn-sm btn-primary h-8 p-0 rounded-none'

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -4,17 +4,18 @@
   h1.text-3xl.font-bold 
     | #{current_user.username} さんのマイグラフ
 
+  / 検索フォーム
+  = search_form_for @q, url: graphs_path do |f|
+    .flex.justify-start.space-x-2.my-5
+      = f.search_field :title_cont, class: 'input input-primary w-96 h-8 pl-3 pr-2 rounded-lg', placeholder: 'タイトルまたは都市名を入力'
+      = f.submit '検索', class: 'btn btn-sm btn-primary h-8'
+
   .flex.flex-row.justify-end.space-x-1.mr-5
     = link_to graphs_path(view_mode: 'table'), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do 
       img class="inline-block w-8 h-8 stroke-current" src="/images/list.svg" alt=""
     = link_to graphs_path(view_mode: 'card'), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do
       img class="inline-block w-8 h-8 stroke-current" src="/images/squares-four.svg" alt=""
 
-  / 検索フォーム
-  = search_form_for @q, url: graphs_path do |f|
-    .flex.justify-end.space-x-1.mb-10
-      = f.search_field :title_cont, class: 'form-input w-96 h-8 rounded-none', placeholder: 'グラフ名で検索'
-      = f.submit '検索', class: 'btn btn-sm btn-primary h-8 p-0 rounded-none'
 
 
   - if @view_mode == 'table'

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -10,6 +10,12 @@
     = link_to graphs_path(view_mode: 'card'), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do
       img class="inline-block w-8 h-8 stroke-current" src="/images/squares-four.svg" alt=""
 
+  = search_form q: @q, url: graphs_path do |f|
+    .flex.justify-end.space-x-1.mb-10
+      = f.search_field :title_cont, class: 'form-input w-96 h-8 rounded-none', placeholder: 'グラフ名で検索'
+      = f.submit '検索', class: 'btn btn-sm btn-primary h-8 p-0 rounded-none'
+
+
   - if @view_mode == 'table'
     = render partial: 'table_view', locals: { graphs: @graphs }
   - else


### PR DESCRIPTION
次のissue項目を完了しました
https://github.com/g-sawada/u-on-zu/issues/56

- ransack 4より，modelに検索可能なカラムや関連テーブルを明示する必要があるようです。
- 現在、マイグラフのタイトルだけ検索可能としています。

