### PR TITLE
マイグラフ一覧の検索に都市名を対応・ビュー形式の切り替えで検索結果を引き継ぐ

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -3,7 +3,7 @@ class GraphsController < ApplicationController
 
   def index
     @q = current_user.graphs.ransack(params[:q])
-    @graphs = @q.result(distinct: true).order(created_at: :desc)
+    @graphs = @q.result(distinct: true).includes(:city).order(created_at: :desc)
     @view_mode = params[:view_mode] || cookies[:view_mode] || "table" # デフォルトはテーブル表示
     cookies[:view_mode] = @view_mode
   end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -5,7 +5,7 @@ class City < ApplicationRecord
   validates :name, presence: true
   validates :data, presence: true
 
-  def self.ransackable_attributes(_auth_object = nil)
+  def self.ransackable_attributes(auth_object = nil)
     %w[name]
   end
 end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -4,4 +4,8 @@ class City < ApplicationRecord
 
   validates :name, presence: true
   validates :data, presence: true
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name]
+  end
 end

--- a/app/models/graph.rb
+++ b/app/models/graph.rb
@@ -15,6 +15,6 @@ class Graph < ApplicationRecord
   end
 
   def self.ransackable_associations(_auth_object = nil)
-    []
+    %w[city]
   end
 end

--- a/app/models/graph.rb
+++ b/app/models/graph.rb
@@ -10,11 +10,11 @@ class Graph < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :note, length: { maximum: 65_535 }
 
-  def self.ransackable_attributes(_auth_object = nil)
+  def self.ransackable_attributes(auth_object = nil)
     %w[title note created_at updated_at]
   end
 
-  def self.ransackable_associations(_auth_object = nil)
+  def self.ransackable_associations(auth_object = nil)
     %w[city]
   end
 end

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -7,7 +7,7 @@
   / 検索フォーム
   = search_form_for @q, url: graphs_path do |f|
     .flex.justify-start.space-x-2.my-5
-      = f.search_field :title_cont, class: 'input input-primary w-96 h-8 pl-3 pr-2 rounded-lg', placeholder: 'タイトルまたは都市名を入力'
+      = f.search_field :title_or_city_name_cont, class: 'input input-primary w-96 h-8 pl-3 pr-2 rounded-lg', placeholder: 'タイトルまたは都市名を入力'
       = f.submit '検索', class: 'btn btn-sm btn-primary h-8'
 
   .flex.flex-row.justify-end.space-x-1.mr-5

--- a/app/views/graphs/index.html.slim
+++ b/app/views/graphs/index.html.slim
@@ -11,9 +11,9 @@
       = f.submit '検索', class: 'btn btn-sm btn-primary h-8'
 
   .flex.flex-row.justify-end.space-x-1.mr-5
-    = link_to graphs_path(view_mode: 'table'), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do 
+    = link_to graphs_path(view_mode: 'table', q: params[:q].to_unsafe_h), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do 
       img class="inline-block w-8 h-8 stroke-current" src="/images/list.svg" alt=""
-    = link_to graphs_path(view_mode: 'card'), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do
+    = link_to graphs_path(view_mode: 'card', q: params[:q].to_unsafe_h), class: 'btn btn-sm btn-ghost h-8 p-0 rounded-none' do
       img class="inline-block w-8 h-8 stroke-current" src="/images/squares-four.svg" alt=""
 
 

--- a/app/views/static_pages/release_note.html.slim
+++ b/app/views/static_pages/release_note.html.slim
@@ -19,12 +19,22 @@
   h2.text-2xl.font-bold.mt-10
     | リリースノート
 
+  / 2024/06/xx
+  .my-16
+    h3.text-xl.font-bold.ml-5.mb-3
+      | 2024/06/xx
+    .ml-10
+      p.text-lg.font-bold.mb-2
+        | マイグラフ一覧ページに検索機能を追加しました🔍
+      ul.list-disc.ml-5
+        li.mb-2 タイトルまたは都市名から，保存したマイグラフを検索できるようになりました。
+
   / 2024/06/18
   .my-16
     h3.text-xl.font-bold.ml-5.mb-3
       | 2024/06/18
     .ml-10
-      p.mb-2
+      p.text-lg.font-bold.mb-2
         | トップページをリニューアルしました😆
       ul.list-disc.ml-5
         li.mb-2 サービス内容をわかりやすくご覧頂けるようになりました。
@@ -35,7 +45,7 @@
     h3.text-xl.font-bold.ml-5.mb-3
       | 2024/06/15
     .ml-10
-      p.mb-2
+      p.text-lg.font-bold.mb-2
         | マイグラフ機能を大幅アップデートしました📊
       ul.list-disc.ml-5
         li.mb-2 マイグラフ一覧ページで、サムネイル付きのカードビューをご利用頂けるようになりました。
@@ -47,7 +57,7 @@
     h3.text-xl.font-bold.ml-5.mb-3
       | 🎉2024/06/07🎉
     .ml-10
-      p.mb-2
+      p.text-lg.font-bold.mb-2
         | Hello, World!! クローズドβ版をリリースしました🐘🌎🐘
       ul.list-disc.ml-5
         li.mb-2 全国の気象台，151地点のデータをご利用いただけます


### PR DESCRIPTION
- Ransackバージョン4から、モデルで明示的に検索対象カラムと関連テーブルの登録が必要となったので記述し，検索クエリを次のようにして，マイグラフのタイトルまたは都市名で部分一致検索ができるようにしました
```f.search_field :title_or_city_name_cont,```

- テーブルビューとカードビューの切り替えボタンをクリックした時，検索結果がリセットされてしまう状態だったため，切り替えボタンのlink_toにparams[:q] を引き渡して，検索結果を引き継ぐようにしました。
- ただしこのとき，ストロングパラメータにないparamsをハッシュに変換するためRailsのセキュリティに引っかかってしまうので，to_unsafe_hメソッドを用いてフィルタリングをバイパスさせました（リファクタ対象？）